### PR TITLE
Setup continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "6"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kozily web
 
+[![Build Status](https://travis-ci.org/kozily/web.svg?branch=master)](https://travis-ci.org/kozily/web)
+
 Kozily client, progressive web application for developing and interaction with
 an Oz program.
 
@@ -42,7 +44,10 @@ any development environment commands.
 The commands are defined in the `package.json` file:
 
 * `dev/run npm start`: Starts a development server at the local port 8080,
-  setup to autoreload if you change files.
+  setup to autoreload if you change files and lint your code on each save..
+
+* `dev/run npm test`: Runs the test suite for the project, linting your code
+  before doing so.
 
 * `dev/run npm run build`: Builds a bundle at the local `build` directory
   containing the whole application as a set of html, js and css files, ready to

--- a/app/sum.jsx
+++ b/app/sum.jsx
@@ -1,0 +1,4 @@
+// This is a sample module to be tested
+export default function (a, b) {
+  return a + b;
+}

--- a/config/karma.js
+++ b/config/karma.js
@@ -1,0 +1,37 @@
+const path = require('path');
+
+module.exports = function(config) {
+  config.set({
+    basePath: '..',
+    frameworks: ['jasmine'],
+    files: [
+      'specs/*_spec.js',
+      'specs/**/*_spec.js',
+    ],
+    preprocessors: {
+      'specs/*_spec.js': ['webpack'],
+      'specs/**/*_spec.js': ['webpack'],
+    },
+    reporters: ['dots'],
+    browsers: ['PhantomJS'],
+    webpack: {
+      resolve: {
+        extensions: [
+          '',
+          '.js',
+          '.jsx',
+        ],
+      },
+
+      module: {
+        loaders: [
+          {
+            test: /\.jsx?$/,
+            exclude: /node_modules/,
+            loader: 'babel',
+          },
+        ]
+      }
+    },
+  });
+}

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -9,9 +9,6 @@ module.exports = {
   ],
 
   resolve: {
-    root: [
-      path.resolve('./app'),
-    ],
     extensions: [
       '',
       '.js',

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -11,9 +11,6 @@ module.exports = {
   },
 
   resolve: {
-    root: [
-      path.resolve('./app'),
-    ],
     extensions: [
       '',
       '.js',

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.22.0",
+    "jasmine": "^2.5.2",
+    "karma": "^1.3.0",
+    "karma-jasmine": "^1.0.2",
+    "karma-phantomjs-launcher": "^1.0.2",
+    "karma-webpack": "^1.8.0",
     "node-sass": "^3.9.3",
     "react-hot-loader": "^3.0.0-beta.3",
     "sass-loader": "^4.0.2",
@@ -46,6 +51,8 @@
   },
   "scripts": {
     "start": "webpack-dev-server --config config/webpack.dev.js --hot --inline --host 0.0.0.0 --port 8080",
+    "pretest": "eslint 'app/**/*.jsx' 'specs/**/*.js'",
+    "test": "karma start config/karma.js --single-run",
     "build": "rm -rf build && NODE_ENV=production webpack --config config/webpack.prod.js --progress -p"
   },
   "eslintConfig": {
@@ -59,7 +66,8 @@
       "import"
     ],
     "env": {
-      "browser": true
+      "browser": true,
+      "jasmine": true
     }
   },
   "babel": {

--- a/specs/sum_spec.js
+++ b/specs/sum_spec.js
@@ -1,0 +1,7 @@
+import sum from '../app/sum';
+
+describe('A sample suite', () => {
+  it('contains a spec with an expectation', () => {
+    expect(sum(1, 2)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary of changes

Sets up karma with phantom js to run specs through jasmine. Specs are run in the development environment with `dev/run npm test`. Travis is also monitoring pushes and pull requests, and should include a banner here in the PR's indicating tests have passed or not.

I added a small sample module and spec to make sure everything works. This should go away once we start implementing actual tests in here.

## Related issues

* Needs https://github.com/kozily/web/pull/1 merged first.
* Closes https://github.com/kozily/admin/issues/28.



