### PR TITLE
Setup continuous delivery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
 language: node_js
 node_js:
   - "6"
+
+deploy:
+  provider: surge
+  project: build
+  domain: https://kozily.surge.sh
+  skip_cleanup: true
+  on: master

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -7,7 +7,6 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 module.exports = {
   entry: {
     app: './app/index.jsx',
-    vendor: ['react', 'react-dom'],
   },
 
   resolve: {
@@ -50,6 +49,11 @@ module.exports = {
       template: './app/index.html',
     }),
 
+    new HtmlPlugin({
+      template: './app/index.html',
+      filename: '200.html',
+    }),
+
     new CopyPlugin([
       {from: './app/favicons', to: './'},
     ]),
@@ -64,10 +68,6 @@ module.exports = {
       "[name]-[contenthash].css",
       {allChunks: true}
     ),
-
-    new webpack.optimize.CommonsChunkPlugin({
-      names: ['vendor', 'manifest'],
-    }),
   ],
 };
 


### PR DESCRIPTION
## Summary of changes

Sets up travis ci to push all commits in master to [surge](https://surge.sh/). This is way simpler than github pages, and it has sane default caching, cient-side routing support, ec.

This also includes a minor change to webpack, the production build system was broken when trying to split vendor and app code.

## Related issues

* Closes kozily/admin#27
* Requires https://github.com/kozily/web/pull/2 merged first.


