### PR TITLE
Implements automatic dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8
+
+# Setup the project directory
+RUN mkdir -p /opt/project
+WORKDIR /opt/project
+
+# Setup the application dependencies
+COPY package*.json /opt/project/
+RUN npm install
+
+# Setup the application code
+COPY app /opt/project/app
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  dev:
+    image: kozily/web
+    build: .
+    command: npm start
+    volumes:
+      - "./app:/opt/project/app"
+      - "./config:/opt/project/config"
+      - "./package.json:/opt/project/package.json"
+      - "./specs:/opt/project/specs"
+    ports:
+      - "8080:8080"
+


### PR DESCRIPTION
Through docker-compose, only docker-compose up is required now to start the development server.

## Summary of changes

* Configures docker compose and docker to cache dependencies on development server startup

## Related issues

* Closes kozily/admin#59


