### PR TITLE
Implements tuple literals

### DIFF
--- a/app/oz/grammar/lexical.nearley
+++ b/app/oz/grammar/lexical.nearley
@@ -22,6 +22,7 @@ lexical_value ->
   | lexical_integer {% id %}
   | lexical_float {% id %}
   | lexical_list {% id %}
+  | lexical_tuple {% id %}
 
 ##############################################################################
 # Variable identifiers
@@ -315,11 +316,28 @@ empty_list -> "[" _ "]" {%
 
 list_items ->
     lexical_variable
-  | lexical_variable __ list_items {%
+  | list_items __ lexical_variable {%
       function(d) {
-        return d[2].concat(d[0]);
+        return d[0].concat(d[2]);
       }
     %}
+
+
+
+##############################################################################
+# Tuple
+##############################################################################
+
+lexical_tuple -> lexical_atom_syntax "(" _ list_items _ ")" {%
+  function(d, position, reject) {
+    var label = d[0];
+    var features = d[3].reduce(function(result, item, index) {
+      result[++index] = item;
+      return result;
+    }, {});
+    return lexicalRecord(label, features);
+  }
+%}
 
 ##############################################################################
 # Library of helpful terminals and functions

--- a/specs/parser/lexical/tuple_spec.js
+++ b/specs/parser/lexical/tuple_spec.js
@@ -1,0 +1,48 @@
+import Immutable from "immutable";
+import { lexicalVariable, lexicalTuple } from "../../samples/lexical";
+import { parserFor } from "../../../app/oz/parser";
+import lexicalGrammar from "../../../app/oz/grammar/lexical.nearley";
+
+const parse = parserFor(lexicalGrammar);
+
+describe("Parsing lexical tuple elements", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("handles the standard syntax", () => {
+    expect(parse("label(X Y)")).toEqual(
+      lexicalTuple("label", [lexicalVariable("X"), lexicalVariable("Y")]),
+    );
+  });
+
+  it("handles the standard syntax with a single feature", () => {
+    expect(parse("label(X)")).toEqual(
+      lexicalTuple("label", [lexicalVariable("X")]),
+    );
+  });
+
+  it("handles the standard syntax with a single multicharacter feature", () => {
+    expect(parse("label(Feature)")).toEqual(
+      lexicalTuple("label", [lexicalVariable("Feature")]),
+    );
+  });
+
+  it("handles the standard syntax with whitespaces", () => {
+    expect(parse("label(\n  X\n  Y\n)")).toEqual(
+      lexicalTuple("label", [lexicalVariable("X"), lexicalVariable("Y")]),
+    );
+  });
+
+  it("handles the standard syntax with a single feature and whitespaces", () => {
+    expect(parse("label(  X\n  \n)")).toEqual(
+      lexicalTuple("label", [lexicalVariable("X")]),
+    );
+  });
+
+  it("handles a quoted label syntax", () => {
+    expect(parse("'andthen'(X Y)")).toEqual(
+      lexicalTuple("andthen", [lexicalVariable("X"), lexicalVariable("Y")]),
+    );
+  });
+});

--- a/specs/samples/lexical.js
+++ b/specs/samples/lexical.js
@@ -19,11 +19,14 @@ export const lexicalBoolean = value => {
   return lexicalRecord(value.toString());
 };
 
-export const lexicalTuple = (label, first, second) => {
-  return lexicalRecord(label, {
-    1: first,
-    2: second,
-  });
+export const lexicalTuple = (label, tuples = []) => {
+  return lexicalRecord(
+    label,
+    tuples.reduce((accumulator, value, index) => {
+      accumulator[++index] = value;
+      return accumulator;
+    }, {}),
+  );
 };
 
 export const lexicalNil = () => {
@@ -31,11 +34,11 @@ export const lexicalNil = () => {
 };
 
 export const lexicalList = (head, tail) => {
-  return lexicalTuple("|", head, tail);
+  return lexicalTuple("|", [head, tail]);
 };
 
 export const lexicalComplexList = array => {
-  return array.reduceRight(
+  return array.reduce(
     (result, item) => lexicalList(lexicalVariable(item), result),
     lexicalNil(),
   );


### PR DESCRIPTION
## Summary of changes

* Adds the parser for tuple literals
* Adjusts the order in the list items parsed
* Adds tests for tuple literals

The application is parsing and executing the following example correctly:
```
local X in local Y in local Vector in
  Vector = vector(X Y)
end end end
```

## Related issues

* Closes kozily/admin#51


