### PR TITLE
Build in operators

### DIFF
--- a/app/oz/reducers/build_in_operation.js
+++ b/app/oz/reducers/build_in_operation.js
@@ -1,0 +1,138 @@
+import { lookupVariableInStore } from "../machine/store";
+import { lexicalNumber } from "../../../specs/samples/lexical";
+import Immutable from "immutable";
+
+class ValueOperation {
+  constructor() {
+    this.node = "Value";
+    this.operations = Immutable.Map({
+      "==": this.equals,
+      "\\=": this.assign,
+      "<": this.lessThan,
+      "=<": this.equalOrLessThan,
+      ">": this.greaterThan,
+      ">=": this.equalOrGreaterThan,
+    });
+  }
+  equals(a, b) {
+    return a === b;
+  }
+  assign(a, b) {
+    return (a = b);
+  }
+  lessThan(a, b) {
+    return a < b;
+  }
+  equalOrLessThan(a, b) {
+    return a <= b;
+  }
+  greaterThan(a, b) {
+    return a > b;
+  }
+  equalOrGreaterThan(a, b) {
+    return a >= b;
+  }
+}
+
+class NumberOperation extends ValueOperation {
+  constructor() {
+    super();
+    this.type = "Number";
+    var current = Immutable.Map({
+      "+": this.sum,
+      "-": this.substract,
+      "*": this.multiplicate,
+      "/": this.divide,
+      mod: this.mod,
+    });
+    this.operations = this.operations.merge(current);
+  }
+  sum(a, b) {
+    return a + b;
+  }
+  substract(a, b) {
+    return a - b;
+  }
+  multiplicate(a, b) {
+    return a * b;
+  }
+  divide(a, b) {
+    if (b === 0) throw new Error("cannot divide by zero");
+    return a / b;
+  }
+  mod(a, b) {
+    return a % b;
+  }
+}
+
+export default function(state, semanticStatement) {
+  const store = state.get("store");
+  const statement = semanticStatement.get("statement");
+  const environment = semanticStatement.get("environment");
+
+  const operator = statement.get("operator");
+  const kind = statement.get("kind");
+  const variables = statement.get("variables");
+
+  // validators
+  if (variables.size < 2 || variables.size > 3) {
+    throw new Error(
+      `The amount of variables ${identifiers} are not supported for the operation ${operator}`,
+    );
+  }
+
+  // get the identifiers of the variables
+  const identifiers = variables.map(x => x.get("identifier"));
+
+  const equivalentClasses = identifiers.map(id => {
+    // check what means in environment
+    const variable = environment.get(id);
+    // check what points in store
+    const equivalentClass = lookupVariableInStore(store, variable);
+
+    return equivalentClass;
+  });
+
+  const valuesInStore = equivalentClasses.map(x => x.get("value"));
+
+  const validValues = valuesInStore.map((value, index) => {
+    // validates that first variables must have the same kind
+    if (index < variables.size) {
+      if (value === undefined)
+        throw new Error(
+          `Unbound value in variable ${identifiers[
+            index
+          ]} for the operation ${operator}`,
+        );
+
+      const node = value.get("node");
+      const type = value.get("type");
+      //if kind is different from Value, eval the type
+      if (
+        (kind !== "Value" && type !== kind.toLowerCase()) ||
+        (kind === "Value" && node !== kind.toLowerCase())
+      )
+        throw new Error(
+          `The variable ${identifiers[
+            index
+          ]} of type ${node}-${type} is not support for the build-in operation ${kind} ${operator}`,
+        );
+
+      return value;
+    }
+  });
+
+  // executes the operation
+  if (validValues.size === 3) {
+    const result = new NumberOperation().operations.get(operator)(
+      validValues.getIn(["1", "value"]),
+      validValues.getIn(["2", "value"]),
+    );
+
+    const oldEC = equivalentClasses.get("3");
+    const newEC = oldEC.update("value", () => lexicalNumber(result));
+    return state.update("store", store => store.delete(oldEC).add(newEC));
+  }
+
+  return state;
+}

--- a/app/oz/reducers/index.js
+++ b/app/oz/reducers/index.js
@@ -4,6 +4,7 @@ import local from "./local";
 import binding from "./binding";
 import valueCreation from "./value_creation";
 import conditional from "./conditional";
+import buildInOperation from "./build_in_operation";
 
 export default {
   skip,
@@ -12,4 +13,5 @@ export default {
   binding,
   valueCreation,
   conditional,
+  buildInOperation,
 };

--- a/specs/parser/statements/build_in_operator_spec.js
+++ b/specs/parser/statements/build_in_operator_spec.js
@@ -1,0 +1,167 @@
+import Immutable from "immutable";
+import { lexicalVariable } from "../../samples/lexical";
+import { buildInOperatorStatement } from "../../samples/statements";
+import parse from "../../../app/oz/parser";
+
+describe("Parsing build-in operator statements", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("make two variables of type Value apply equal operation and then an asignation", () => {
+    expect(parse("{Value.`==` X Y Z}")).toEqual(
+      buildInOperatorStatement("Value", "==", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Value apply assignate operation and then an asignation", () => {
+    expect(parse("{Value.`\\=` X Y Z}")).toEqual(
+      buildInOperatorStatement("Value", "\\=", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Value apply less than operation and then an asignation", () => {
+    expect(parse("{Value.`=<` X Y Z}")).toEqual(
+      buildInOperatorStatement("Value", "=<", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Value apply less operation and then an asignation", () => {
+    expect(parse("{Value.`<` X Y Z}")).toEqual(
+      buildInOperatorStatement("Value", "<", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Value apply greater operation and then an asignation", () => {
+    expect(parse("{Value.`>` X Y Z}")).toEqual(
+      buildInOperatorStatement("Value", ">", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Value apply greater than operation and then an asignation", () => {
+    expect(parse("{Value.`>=` X Y Z}")).toEqual(
+      buildInOperatorStatement("Value", ">=", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Number apply plus operation and then an asignation", () => {
+    expect(parse("{Number.`+` X Y Z}")).toEqual(
+      buildInOperatorStatement("Number", "+", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Number apply substraction operation and then an asignation", () => {
+    expect(parse("{Number.`-` X Y Z}")).toEqual(
+      buildInOperatorStatement("Number", "-", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Number apply multiplicate operation and then an asignation", () => {
+    expect(parse("{Number.`*` X Y Z}")).toEqual(
+      buildInOperatorStatement("Number", "*", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Number apply division operation and then an asignation", () => {
+    expect(parse("{Number.`div` X Y Z}")).toEqual(
+      buildInOperatorStatement("Number", "div", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Number apply modular operation and then an asignation", () => {
+    expect(parse("{Number.`mod` X Y Z}")).toEqual(
+      buildInOperatorStatement("Number", "mod", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Float apply division operation and then an asignation", () => {
+    expect(parse("{Float.`/` X Y Z}")).toEqual(
+      buildInOperatorStatement("Float", "/", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("make two variables of type Record apply dot operation and then an asignation", () => {
+    expect(parse("{Record.`.` X Y Z}")).toEqual(
+      buildInOperatorStatement("Record", ".", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+        lexicalVariable("Z"),
+      ]),
+    );
+  });
+
+  it("check if a variable is procedure operation and then an asignation", () => {
+    expect(parse("{IsProcedure X Y}")).toEqual(
+      buildInOperatorStatement("Procedure", "IsProcedure", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+      ]),
+    );
+  });
+
+  it("apply arity operation over a variable and then an asignation", () => {
+    expect(parse("{Arity X Y}")).toEqual(
+      buildInOperatorStatement("Record", "Arity", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+      ]),
+    );
+  });
+
+  it("apply label operation over a variable and then an asignation", () => {
+    expect(parse("{Label X Y}")).toEqual(
+      buildInOperatorStatement("Record", "Label", [
+        lexicalVariable("X"),
+        lexicalVariable("Y"),
+      ]),
+    );
+  });
+});

--- a/specs/samples/statements.js
+++ b/specs/samples/statements.js
@@ -56,3 +56,16 @@ export const conditionalStatement = (
     false_statement,
   });
 };
+
+export const buildInOperatorStatement = (kind, operator, variables) => {
+  return Immutable.fromJS({
+    node: "statement",
+    type: "buildInOperation",
+    operator,
+    kind,
+    variables: variables.reduce((accumulator, value, index) => {
+      accumulator[++index] = value;
+      return accumulator;
+    }, {}),
+  });
+};


### PR DESCRIPTION
## DON'T MERGE!!

## Summary of changes

* The parser recognizes the build-in operators defined in kozily/admin#48
* Adds reducer for build-in operations
* Implementing a hierarchy in supported operations
* Validate the expected kinds
* The following example is working:
```
local X in local Y in local Z in
X = 5
Y = 10
{Number.`+` X Y Z}
end end end
```

## Related issues

* Closes kozily/admin#48

## DON'T MERGE!!
