### PR TITLE
Implements multiple identifier declaration for local statements

### DIFF
--- a/app/oz/compilation/local.js
+++ b/app/oz/compilation/local.js
@@ -1,8 +1,11 @@
 import { localStatement } from "../machine/statements";
 
 export default (recurse, statement) => {
-  return localStatement(
-    statement.get("identifier"),
-    recurse(statement.get("statement")),
+  const childStatement = recurse(statement.get("statement"));
+  const identifiers = statement.get("identifiers");
+
+  return identifiers.reduceRight(
+    (child, identifier) => localStatement(identifier, child),
+    childStatement,
   );
 };

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -42,16 +42,24 @@ stm_skip -> "skip" {%
   }
 %}
 
-stm_local -> "local" __ ids_identifier __ "in" __ stm_sequence __ "end" {%
+stm_local -> "local" __ stm_local_identifier_list __ "in" __ stm_sequence __ "end" {%
   function(d) {
     return {
       node: "statement",
       type: "localSyntax",
-      identifier: d[2],
+      identifiers: d[2],
       statement: d[6],
     };
   }
 %}
+
+stm_local_identifier_list ->
+    ids_identifier
+  | stm_local_identifier_list __ ids_identifier {%
+    function(d) {
+      return d[0].concat(d[2]);
+    }
+  %}
 
 stm_binding -> ids_identifier _ "=" _ ids_identifier {%
   function(d, position, reject) {

--- a/app/oz/machine/statementSyntax.js
+++ b/app/oz/machine/statementSyntax.js
@@ -32,11 +32,11 @@ export const skipStatementSyntax = () => {
   });
 };
 
-export const localStatementSyntax = (identifier, statement) => {
-  return new Immutable.Map({
+export const localStatementSyntax = (identifiers, statement) => {
+  return new Immutable.fromJS({
     node: "statement",
     type: statementSyntaxTypes.localSyntax,
-    identifier,
+    identifiers: identifiers,
     statement,
   });
 };

--- a/specs/compilation/local_spec.js
+++ b/specs/compilation/local_spec.js
@@ -14,12 +14,33 @@ describe("Compiling local statements", () => {
 
   it("compiles appropriately", () => {
     const statement = localStatementSyntax(
-      lexicalIdentifier("X"),
+      [lexicalIdentifier("X")],
       skipStatementSyntax(),
     );
 
     expect(compile(statement)).toEqual(
       localStatement(lexicalIdentifier("X"), skipStatement()),
+    );
+  });
+
+  it("compiles appropriately when using multiple identifierrs", () => {
+    const statement = localStatementSyntax(
+      [
+        lexicalIdentifier("X"),
+        lexicalIdentifier("Y"),
+        lexicalIdentifier("Variable"),
+      ],
+      skipStatementSyntax(),
+    );
+
+    expect(compile(statement)).toEqual(
+      localStatement(
+        lexicalIdentifier("X"),
+        localStatement(
+          lexicalIdentifier("Y"),
+          localStatement(lexicalIdentifier("Variable"), skipStatement()),
+        ),
+      ),
     );
   });
 });

--- a/specs/parser/statements/local_spec.js
+++ b/specs/parser/statements/local_spec.js
@@ -11,18 +11,48 @@ describe("Parsing local X in ... end statements", () => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  it("handles it correctly", () => {
-    expect(parse("local Variable in skip end")).toEqual(
-      localStatementSyntax(
-        lexicalIdentifier("Variable"),
-        skipStatementSyntax(),
-      ),
-    );
+  describe("when using single variables", () => {
+    it("handles declarations correctly", () => {
+      expect(parse("local Variable in skip end")).toEqual(
+        localStatementSyntax(
+          [lexicalIdentifier("Variable")],
+          skipStatementSyntax(),
+        ),
+      );
+    });
+
+    it("handles spaces correctly", () => {
+      expect(parse("local Xyz in\n  skip\n end")).toEqual(
+        localStatementSyntax([lexicalIdentifier("Xyz")], skipStatementSyntax()),
+      );
+    });
   });
 
-  it("handles spaces correctly", () => {
-    expect(parse("local Xyz in\n  skip\n end")).toEqual(
-      localStatementSyntax(lexicalIdentifier("Xyz"), skipStatementSyntax()),
-    );
+  describe("when using multiple variables", () => {
+    it("handles declarations correctly", () => {
+      expect(parse("local X Y Variable in skip end")).toEqual(
+        localStatementSyntax(
+          [
+            lexicalIdentifier("X"),
+            lexicalIdentifier("Y"),
+            lexicalIdentifier("Variable"),
+          ],
+          skipStatementSyntax(),
+        ),
+      );
+    });
+
+    it("handles declarations correctly", () => {
+      expect(parse("local X \nY\t Variable \n\t   in\n  skip\nend")).toEqual(
+        localStatementSyntax(
+          [
+            lexicalIdentifier("X"),
+            lexicalIdentifier("Y"),
+            lexicalIdentifier("Variable"),
+          ],
+          skipStatementSyntax(),
+        ),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary of changes

The `local` statement now allows multiple identifiers to be defined in a single statement

## Related issues

* Closes kozily/admin#91



