### PR TITLE
86 builin value operations

### DIFF
--- a/app/oz/compilation/index.js
+++ b/app/oz/compilation/index.js
@@ -1,5 +1,5 @@
 import { statementSyntaxTypes } from "../machine/statementSyntax";
-import { valueTypes } from "../machine/values";
+import { literalTypes } from "../machine/literals";
 import skip from "./skip";
 import binding from "./binding";
 import sequence from "./sequence";
@@ -34,9 +34,9 @@ export const compilers = {
     [statementSyntaxTypes.byNeedSyntax]: byNeed,
   },
   literal: {
-    [valueTypes.number]: number,
-    [valueTypes.record]: record,
-    [valueTypes.procedure]: procedure,
+    [literalTypes.number]: number,
+    [literalTypes.record]: record,
+    [literalTypes.procedure]: procedure,
   },
 };
 

--- a/app/oz/execution/builtin.js
+++ b/app/oz/execution/builtin.js
@@ -1,0 +1,46 @@
+import {
+  makeNewVariable,
+  lookupVariableInSigma,
+  unify,
+} from "../machine/sigma";
+import {
+  makeAuxiliaryIdentifier,
+  buildEquivalenceClass,
+} from "../machine/build";
+import { builtIns } from "../machine/builtIns";
+
+export const newSigmaAfterBuiltIn = (
+  sigma,
+  namespace,
+  operator,
+  argumentValues,
+  resultVariable,
+) => {
+  const builtIn = builtIns[namespace][operator];
+  if (builtIn === undefined) {
+    throw new Error("Builtin operation is not defined");
+  }
+  const value = builtIn.handler(argumentValues);
+  const aux = makeAuxiliaryIdentifier();
+  const newVariable = makeNewVariable({
+    in: sigma,
+    for: aux.get("identifier"),
+  });
+  const newEquivalenceClass = buildEquivalenceClass(value, newVariable);
+  const newSigma = sigma.add(newEquivalenceClass);
+
+  const unifiedSigma = unify(newSigma, resultVariable, newVariable);
+  const resultingEquivalenceClass = lookupVariableInSigma(
+    unifiedSigma,
+    newVariable,
+  );
+  const cleanUnifiedSigma = unifiedSigma
+    .delete(resultingEquivalenceClass)
+    .add(
+      resultingEquivalenceClass.update("variables", variables =>
+        variables.delete(newVariable),
+      ),
+    );
+
+  return cleanUnifiedSigma;
+};

--- a/app/oz/execution/builtin/float.js
+++ b/app/oz/execution/builtin/float.js
@@ -1,0 +1,5 @@
+import procedureApplication from "../procedure_application";
+
+export default function(state, semanticStatement, activeThreadIndex) {
+  return procedureApplication(state, semanticStatement, activeThreadIndex);
+}

--- a/app/oz/execution/builtin/number.js
+++ b/app/oz/execution/builtin/number.js
@@ -1,0 +1,5 @@
+import procedureApplication from "../procedure_application";
+
+export default function(state, semanticStatement, activeThreadIndex) {
+  return procedureApplication(state, semanticStatement, activeThreadIndex);
+}

--- a/app/oz/execution/builtin/value.js
+++ b/app/oz/execution/builtin/value.js
@@ -1,0 +1,5 @@
+import procedureApplication from "../procedure_application";
+
+export default function(state, semanticStatement, activeThreadIndex) {
+  return procedureApplication(state, semanticStatement, activeThreadIndex);
+}

--- a/app/oz/execution/index.js
+++ b/app/oz/execution/index.js
@@ -15,6 +15,7 @@ import thread from "./thread";
 import byNeed from "./by_need";
 import builtInNumber from "./builtin/number";
 import builtInFloat from "./builtin/float";
+import builtInValue from "./builtin/value";
 
 export const executors = {
   statement: {
@@ -36,6 +37,7 @@ export const executors = {
     builtIn: {
       [builtInTypes.Number]: builtInNumber,
       [builtInTypes.Float]: builtInFloat,
+      [builtInTypes.Value]: builtInValue,
     },
   },
 };

--- a/app/oz/execution/index.js
+++ b/app/oz/execution/index.js
@@ -1,5 +1,5 @@
 import { statementTypes } from "../machine/statements";
-import { builtInTypes } from "../machine/builtins";
+import { builtInTypes } from "../machine/builtIns";
 import skip from "./skip";
 import sequence from "./sequence";
 import local from "./local";

--- a/app/oz/execution/index.js
+++ b/app/oz/execution/index.js
@@ -14,6 +14,7 @@ import exceptionCatch from "./exception_catch";
 import thread from "./thread";
 import byNeed from "./by_need";
 import builtInNumber from "./builtin/number";
+import builtInFloat from "./builtin/float";
 
 export const executors = {
   statement: {
@@ -34,6 +35,7 @@ export const executors = {
   value: {
     builtIn: {
       [builtInTypes.Number]: builtInNumber,
+      [builtInTypes.Float]: builtInFloat,
     },
   },
 };

--- a/app/oz/execution/index.js
+++ b/app/oz/execution/index.js
@@ -1,4 +1,5 @@
 import { statementTypes } from "../machine/statements";
+import { builtInTypes } from "../machine/builtins";
 import skip from "./skip";
 import sequence from "./sequence";
 import local from "./local";
@@ -12,24 +13,40 @@ import exceptionRaise from "./exception_raise";
 import exceptionCatch from "./exception_catch";
 import thread from "./thread";
 import byNeed from "./by_need";
+import builtInNumber from "./builtin/number";
 
 export const executors = {
-  [statementTypes.skip]: skip,
-  [statementTypes.sequence]: sequence,
-  [statementTypes.local]: local,
-  [statementTypes.binding]: binding,
-  [statementTypes.valueCreation]: valueCreation,
-  [statementTypes.conditional]: conditional,
-  [statementTypes.patternMatching]: patternMatching,
-  [statementTypes.procedureApplication]: procedureApplication,
-  [statementTypes.exceptionContext]: exceptionContext,
-  [statementTypes.exceptionRaise]: exceptionRaise,
-  [statementTypes.exceptionCatch]: exceptionCatch,
-  [statementTypes.thread]: thread,
-  [statementTypes.byNeed]: byNeed,
+  statement: {
+    [statementTypes.skip]: skip,
+    [statementTypes.sequence]: sequence,
+    [statementTypes.local]: local,
+    [statementTypes.binding]: binding,
+    [statementTypes.valueCreation]: valueCreation,
+    [statementTypes.conditional]: conditional,
+    [statementTypes.patternMatching]: patternMatching,
+    [statementTypes.procedureApplication]: procedureApplication,
+    [statementTypes.exceptionContext]: exceptionContext,
+    [statementTypes.exceptionRaise]: exceptionRaise,
+    [statementTypes.exceptionCatch]: exceptionCatch,
+    [statementTypes.thread]: thread,
+    [statementTypes.byNeed]: byNeed,
+  },
+  value: {
+    builtIn: {
+      [builtInTypes.Number]: builtInNumber,
+    },
+  },
 };
 
 export const execute = (state, semanticStatement, activeThreadIndex) => {
-  const executor = executors[semanticStatement.getIn(["statement", "type"])];
-  return executor(state, semanticStatement, activeThreadIndex);
+  const statement = semanticStatement.get("statement");
+  const node = statement.get("node");
+  const type = statement.get("type");
+  if (node === "value" && type === "builtIn") {
+    const executor = executors[node][type][statement.get("namespace")];
+    return executor(state, semanticStatement, activeThreadIndex);
+  } else {
+    const executor = executors[node][type];
+    return executor(state, semanticStatement, activeThreadIndex);
+  }
 };

--- a/app/oz/execution/procedure_application.js
+++ b/app/oz/execution/procedure_application.js
@@ -80,20 +80,16 @@ export default function(state, semanticStatement, activeThreadIndex) {
       if (builtIn === undefined) {
         return raiseSystemException(state, activeThreadIndex, errorException());
       }
-      const value = builtIn.handler(
-        userRecordDefinedValues,
-        state,
-        activeThreadIndex,
-      );
-      const aux = makeAuxiliaryIdentifier();
-      const newVariable = makeNewVariable({
-        in: state.get("sigma"),
-        for: aux.get("identifier"),
-      });
-      const newEquivalenceClass = buildEquivalenceClass(value, newVariable);
-      const newSigma = sigma.add(newEquivalenceClass);
-
       try {
+        const value = builtIn.handler(userRecordDefinedValues);
+        const aux = makeAuxiliaryIdentifier();
+        const newVariable = makeNewVariable({
+          in: state.get("sigma"),
+          for: aux.get("identifier"),
+        });
+        const newEquivalenceClass = buildEquivalenceClass(value, newVariable);
+        const newSigma = sigma.add(newEquivalenceClass);
+
         const unifiedSigma = unify(newSigma, bindingVariable, newVariable);
         const resultingEquivalenceClass = lookupVariableInSigma(
           unifiedSigma,

--- a/app/oz/execution/value_creation.js
+++ b/app/oz/execution/value_creation.js
@@ -1,4 +1,9 @@
-import { makeNewVariable, unify, createValue } from "../machine/sigma";
+import {
+  lookupVariableInSigma,
+  makeNewVariable,
+  unify,
+  createValue,
+} from "../machine/sigma";
 import {
   buildEquivalenceClass,
   makeAuxiliaryIdentifier,
@@ -26,8 +31,9 @@ export default function(state, semanticStatement, activeThreadIndex) {
   try {
     const unifiedSigma = unify(newSigma, variable, newVariable);
 
-    const resultingEquivalenceClass = unifiedSigma.find(x =>
-      x.get("variables").contains(newVariable),
+    const resultingEquivalenceClass = lookupVariableInSigma(
+      unifiedSigma,
+      newVariable,
     );
 
     const cleanUnifiedSigma = unifiedSigma

--- a/app/oz/free_identifiers/built_in.js
+++ b/app/oz/free_identifiers/built_in.js
@@ -1,0 +1,5 @@
+import Immutable from "immutable";
+
+export default () => {
+  return Immutable.Set();
+};

--- a/app/oz/free_identifiers/index.js
+++ b/app/oz/free_identifiers/index.js
@@ -1,4 +1,5 @@
 import { statementTypes } from "../machine/statements";
+import { literalTypes } from "../machine/literals";
 import { valueTypes } from "../machine/values";
 import skip from "./skip";
 import binding from "./binding";
@@ -16,6 +17,7 @@ import byNeed from "./by_need";
 import number from "./number";
 import record from "./record";
 import procedure from "./procedure";
+import builtIn from "./built_in";
 
 export const collectors = {
   statement: {
@@ -34,9 +36,15 @@ export const collectors = {
     [statementTypes.byNeed]: byNeed,
   },
   literal: {
+    [literalTypes.number]: number,
+    [literalTypes.record]: record,
+    [literalTypes.procedure]: procedure,
+  },
+  value: {
     [valueTypes.number]: number,
     [valueTypes.record]: record,
     [valueTypes.procedure]: procedure,
+    [valueTypes.builtIn]: builtIn,
   },
 };
 

--- a/app/oz/machine/build.js
+++ b/app/oz/machine/build.js
@@ -1,5 +1,6 @@
 import Immutable from "immutable";
 import { lexicalIdentifier } from "./lexical";
+import { initialize } from "./initialization";
 
 export const buildEnvironment = (contents = {}) => {
   return Immutable.Map(contents);
@@ -102,8 +103,10 @@ export const buildState = ({
 };
 
 export const buildFromKernelAST = ast => {
+  const init = initialize();
   return buildSingleThreadedState({
-    semanticStatements: [buildSemanticStatement(ast)],
+    semanticStatements: [buildSemanticStatement(ast, init.get("environment"))],
+    sigma: init.get("sigma"),
   });
 };
 

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -2,6 +2,7 @@ import { valueTypes, valueNumber } from "./values";
 
 export const builtInTypes = {
   Number: "Number",
+  Float: "Float",
 };
 export const allBuiltInTypes = Object.keys(builtInTypes);
 
@@ -42,6 +43,19 @@ export const builtIns = {
     },
     "/": {
       name: "Numberdivision",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        const divisor = arg2.get("value");
+        if (divisor === 0) throw new Error("cannot divide by zero");
+        return valueNumber(Math.floor(arg1.get("value") / divisor));
+      },
+    },
+  },
+  [builtInTypes.Float]: {
+    "/": {
+      name: "Floatdivision",
       handler: args => {
         const arg1 = args.get(0);
         const arg2 = args.get(1);

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -1,11 +1,30 @@
+import { valueTypes, valueNumber } from "./values";
+import { raiseSystemException, errorException } from "./exceptions";
+
 export const builtInTypes = {
   Number: "Number",
 };
-
 export const allBuiltInTypes = Object.keys(builtInTypes);
 
 export const builtIns = {
   [builtInTypes.Number]: {
-    "+": "Numberplus",
+    "+": {
+      name: "Numberplus",
+      handler: (args, state, activeThreadIndex) => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        if (
+          arg1.get("type") != arg2.get("type") &&
+          arg1.get("type") === valueTypes.number
+        ) {
+          return raiseSystemException(
+            state,
+            activeThreadIndex,
+            errorException(),
+          );
+        }
+        return valueNumber(arg1.get("value") + arg2.get("value"));
+      },
+    },
   },
 };

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -26,5 +26,23 @@ export const builtIns = {
         return valueNumber(arg1.get("value") + arg2.get("value"));
       },
     },
+    "-": {
+      name: "Numberminus",
+      handler: (args, state, activeThreadIndex) => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        if (
+          arg1.get("type") != arg2.get("type") &&
+          arg1.get("type") === valueTypes.number
+        ) {
+          return raiseSystemException(
+            state,
+            activeThreadIndex,
+            errorException(),
+          );
+        }
+        return valueNumber(arg1.get("value") - arg2.get("value"));
+      },
+    },
   },
 };

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -1,0 +1,11 @@
+export const builtInTypes = {
+  Number: "Number",
+};
+
+export const allBuiltInTypes = Object.keys(builtInTypes);
+
+export const builtIns = {
+  [builtInTypes.Number]: {
+    "+": "Numberplus",
+  },
+};

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -44,5 +44,23 @@ export const builtIns = {
         return valueNumber(arg1.get("value") - arg2.get("value"));
       },
     },
+    "*": {
+      name: "Numbermultiplication",
+      handler: (args, state, activeThreadIndex) => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        if (
+          arg1.get("type") != arg2.get("type") &&
+          arg1.get("type") === valueTypes.number
+        ) {
+          return raiseSystemException(
+            state,
+            activeThreadIndex,
+            errorException(),
+          );
+        }
+        return valueNumber(arg1.get("value") * arg2.get("value"));
+      },
+    },
   },
 };

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -1,65 +1,54 @@
 import { valueTypes, valueNumber } from "./values";
-import { raiseSystemException, errorException } from "./exceptions";
 
 export const builtInTypes = {
   Number: "Number",
 };
 export const allBuiltInTypes = Object.keys(builtInTypes);
 
+const typeValidation = (arg1, arg2, type) => {
+  if (arg1.get("type") != arg2.get("type") || arg1.get("type") !== type) {
+    throw new Error(`Some of the arguments are not ${type}`);
+  }
+};
+
 export const builtIns = {
   [builtInTypes.Number]: {
     "+": {
-      name: "Numberplus",
-      handler: (args, state, activeThreadIndex) => {
+      name: "Numberaddition",
+      handler: args => {
         const arg1 = args.get(0);
         const arg2 = args.get(1);
-        if (
-          arg1.get("type") != arg2.get("type") &&
-          arg1.get("type") === valueTypes.number
-        ) {
-          return raiseSystemException(
-            state,
-            activeThreadIndex,
-            errorException(),
-          );
-        }
+        typeValidation(arg1, arg2, valueTypes.number);
         return valueNumber(arg1.get("value") + arg2.get("value"));
       },
     },
     "-": {
-      name: "Numberminus",
-      handler: (args, state, activeThreadIndex) => {
+      name: "Numbersubtraction",
+      handler: args => {
         const arg1 = args.get(0);
         const arg2 = args.get(1);
-        if (
-          arg1.get("type") != arg2.get("type") &&
-          arg1.get("type") === valueTypes.number
-        ) {
-          return raiseSystemException(
-            state,
-            activeThreadIndex,
-            errorException(),
-          );
-        }
+        typeValidation(arg1, arg2, valueTypes.number);
         return valueNumber(arg1.get("value") - arg2.get("value"));
       },
     },
     "*": {
       name: "Numbermultiplication",
-      handler: (args, state, activeThreadIndex) => {
+      handler: args => {
         const arg1 = args.get(0);
         const arg2 = args.get(1);
-        if (
-          arg1.get("type") != arg2.get("type") &&
-          arg1.get("type") === valueTypes.number
-        ) {
-          return raiseSystemException(
-            state,
-            activeThreadIndex,
-            errorException(),
-          );
-        }
+        typeValidation(arg1, arg2, valueTypes.number);
         return valueNumber(arg1.get("value") * arg2.get("value"));
+      },
+    },
+    "/": {
+      name: "Numberdivision",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        const divisor = arg2.get("value");
+        if (divisor === 0) throw new Error("cannot divide by zero");
+        return valueNumber(arg1.get("value") / divisor);
       },
     },
   },

--- a/app/oz/machine/builtIns.js
+++ b/app/oz/machine/builtIns.js
@@ -1,8 +1,9 @@
-import { valueTypes, valueNumber } from "./values";
+import { valueTypes, valueNumber, valueBoolean } from "./values";
 
 export const builtInTypes = {
   Number: "Number",
   Float: "Float",
+  Value: "Value",
 };
 export const allBuiltInTypes = Object.keys(builtInTypes);
 
@@ -63,6 +64,62 @@ export const builtIns = {
         const divisor = arg2.get("value");
         if (divisor === 0) throw new Error("cannot divide by zero");
         return valueNumber(arg1.get("value") / divisor);
+      },
+    },
+  },
+  [builtInTypes.Value]: {
+    "==": {
+      name: "valueequality",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        return valueBoolean(arg1.get("value") === arg2.get("value"));
+      },
+    },
+    "\\=": {
+      name: "valuenonequality",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        return valueBoolean(arg1.get("value") !== arg2.get("value"));
+      },
+    },
+    "=<": {
+      name: "valuelessthanorequal",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        return valueBoolean(arg1.get("value") <= arg2.get("value"));
+      },
+    },
+    "<": {
+      name: "valuelessthan",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        return valueBoolean(arg1.get("value") < arg2.get("value"));
+      },
+    },
+    ">=": {
+      name: "valuegreaterthanorequal",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        return valueBoolean(arg1.get("value") >= arg2.get("value"));
+      },
+    },
+    ">": {
+      name: "valuegreaterthan",
+      handler: args => {
+        const arg1 = args.get(0);
+        const arg2 = args.get(1);
+        typeValidation(arg1, arg2, valueTypes.number);
+        return valueBoolean(arg1.get("value") > arg2.get("value"));
       },
     },
   },

--- a/app/oz/machine/initialization.js
+++ b/app/oz/machine/initialization.js
@@ -1,0 +1,65 @@
+import Immutable from "immutable";
+import {
+  buildEnvironment,
+  buildVariable,
+  buildSigma,
+  buildEquivalenceClass,
+} from "./build";
+import { valueRecord, valueBuiltIn } from "./values";
+import { builtIns } from "./builtIns";
+
+export const initialize = () => {
+  const builtInMapped = Object.keys(builtIns).reduce((acc, recordBuiltIn) => {
+    const variableRecord = buildVariable(recordBuiltIn.toLowerCase(), 0);
+    const recordMap = Immutable.fromJS({ [recordBuiltIn]: variableRecord });
+    const featuresMap = Object.keys(builtIns[recordBuiltIn]).reduce(
+      (acc, item) => {
+        acc[builtIns[recordBuiltIn][item]] = buildVariable(
+          builtIns[recordBuiltIn][item].toLowerCase(),
+          0,
+        );
+        return Immutable.fromJS(acc);
+      },
+      {},
+    );
+    const environment = recordMap.merge(featuresMap);
+
+    const featuresInsideRecord = Object.keys(builtIns[recordBuiltIn]).reduce(
+      (acc, item) => {
+        acc[item] = buildVariable(
+          builtIns[recordBuiltIn][item].toLowerCase(),
+          0,
+        );
+        return Immutable.fromJS(acc);
+      },
+      {},
+    );
+    const sigmaRecordMap = buildEquivalenceClass(
+      valueRecord(recordBuiltIn, featuresInsideRecord),
+      variableRecord,
+    );
+    const sigmaFeaturesMap = Object.keys(builtIns[recordBuiltIn])
+      .reduce((acc, item) => {
+        acc.push({
+          value: valueBuiltIn(item, recordBuiltIn),
+          variable: buildVariable(
+            builtIns[recordBuiltIn][item].toLowerCase(),
+            0,
+          ),
+        });
+        return Immutable.fromJS(acc);
+      }, [])
+      .map(pair => {
+        return buildEquivalenceClass(pair.get("value"), pair.get("variable"));
+      });
+    const sigma = sigmaFeaturesMap.push(sigmaRecordMap);
+    return Immutable.fromJS({ environment, sigma });
+  }, {});
+
+  const environment = buildEnvironment(builtInMapped.get("environment"));
+  const sigma = buildSigma(...builtInMapped.get("sigma").toArray());
+  return Immutable.fromJS({
+    environment,
+    sigma,
+  });
+};

--- a/app/oz/machine/initialization.js
+++ b/app/oz/machine/initialization.js
@@ -6,13 +6,12 @@ import {
   buildEquivalenceClass,
 } from "./build";
 import { valueRecord, valueBuiltIn } from "./values";
-import { builtIns } from "./builtIns";
+import { builtIns, allBuiltInTypes } from "./builtIns";
 
 export const initialize = () => {
-  const builtInMapped = Object.keys(builtIns).reduce((acc, recordBuiltIn) => {
+  const builtInMapped = allBuiltInTypes.reduce((acc, recordBuiltIn) => {
     const variableRecord = buildVariable(recordBuiltIn.toLowerCase(), 0);
-    const recordMap = Immutable.fromJS({ [recordBuiltIn]: variableRecord });
-    const environment = recordMap;
+    const environment = Immutable.fromJS({ [recordBuiltIn]: variableRecord });
 
     const featuresInsideRecord = Object.keys(builtIns[recordBuiltIn]).reduce(
       (acc, item) => {
@@ -43,8 +42,12 @@ export const initialize = () => {
         return buildEquivalenceClass(pair.get("value"), pair.get("variable"));
       });
     const sigma = sigmaFeaturesMap.push(sigmaRecordMap);
-    return Immutable.fromJS({ environment, sigma });
-  }, {});
+    const result = Immutable.fromJS({
+      environment: acc.get("environment").merge(environment),
+      sigma: acc.get("sigma").concat(sigma),
+    });
+    return result;
+  }, Immutable.Map({ environment: Immutable.Map(), sigma: Immutable.List() }));
 
   const environment = buildEnvironment(builtInMapped.get("environment"));
   const sigma = buildSigma(...builtInMapped.get("sigma").toArray());

--- a/app/oz/machine/initialization.js
+++ b/app/oz/machine/initialization.js
@@ -12,27 +12,16 @@ export const initialize = () => {
   const builtInMapped = Object.keys(builtIns).reduce((acc, recordBuiltIn) => {
     const variableRecord = buildVariable(recordBuiltIn.toLowerCase(), 0);
     const recordMap = Immutable.fromJS({ [recordBuiltIn]: variableRecord });
-    const featuresMap = Object.keys(builtIns[recordBuiltIn]).reduce(
-      (acc, item) => {
-        acc[builtIns[recordBuiltIn][item]] = buildVariable(
-          builtIns[recordBuiltIn][item].toLowerCase(),
-          0,
-        );
-        return Immutable.fromJS(acc);
-      },
-      {},
-    );
-    const environment = recordMap.merge(featuresMap);
+    const environment = recordMap;
 
     const featuresInsideRecord = Object.keys(builtIns[recordBuiltIn]).reduce(
       (acc, item) => {
-        acc[item] = buildVariable(
-          builtIns[recordBuiltIn][item].toLowerCase(),
-          0,
+        return acc.set(
+          item,
+          buildVariable(builtIns[recordBuiltIn][item].name.toLowerCase(), 0),
         );
-        return Immutable.fromJS(acc);
       },
-      {},
+      Immutable.Map(),
     );
     const sigmaRecordMap = buildEquivalenceClass(
       valueRecord(recordBuiltIn, featuresInsideRecord),
@@ -40,15 +29,16 @@ export const initialize = () => {
     );
     const sigmaFeaturesMap = Object.keys(builtIns[recordBuiltIn])
       .reduce((acc, item) => {
-        acc.push({
-          value: valueBuiltIn(item, recordBuiltIn),
-          variable: buildVariable(
-            builtIns[recordBuiltIn][item].toLowerCase(),
-            0,
-          ),
-        });
-        return Immutable.fromJS(acc);
-      }, [])
+        return acc.push(
+          Immutable.Map({
+            value: valueBuiltIn(item, recordBuiltIn),
+            variable: buildVariable(
+              builtIns[recordBuiltIn][item].name.toLowerCase(),
+              0,
+            ),
+          }),
+        );
+      }, Immutable.List())
       .map(pair => {
         return buildEquivalenceClass(pair.get("value"), pair.get("variable"));
       });

--- a/app/oz/machine/literals.js
+++ b/app/oz/machine/literals.js
@@ -1,5 +1,13 @@
 import Immutable from "immutable";
 
+export const literalTypes = {
+  number: "number",
+  record: "record",
+  procedure: "procedure",
+};
+
+export const allLiteralTypes = Object.keys(literalTypes);
+
 export const literalRecord = (label, features = {}) => {
   return Immutable.fromJS({
     node: "literal",

--- a/app/oz/machine/values.js
+++ b/app/oz/machine/values.js
@@ -4,6 +4,7 @@ export const valueTypes = {
   number: "number",
   record: "record",
   procedure: "procedure",
+  builtIn: "builtIn",
 };
 
 export const allValueTypes = Object.keys(valueTypes);
@@ -73,5 +74,14 @@ export const valueProcedure = (args = [], body, context = {}) => {
       body,
       context,
     },
+  });
+};
+
+export const valueBuiltIn = (operator, namespace) => {
+  return Immutable.fromJS({
+    node: "value",
+    type: "builtIn",
+    operator,
+    namespace,
   });
 };

--- a/app/oz/print/built_in.js
+++ b/app/oz/print/built_in.js
@@ -1,0 +1,9 @@
+export default (recurse, node, identation) => {
+  const ident = new Array(identation + 1).join(" ");
+  const operator = node.get("operator");
+  const namespace = node.get("namespace");
+  return {
+    abbreviated: `${ident}BuiltIn(${namespace}.'${operator}')`,
+    full: `${ident}BuiltIn(${namespace}.'${operator}')`,
+  };
+};

--- a/app/oz/print/index.js
+++ b/app/oz/print/index.js
@@ -1,5 +1,6 @@
 import { statementTypes } from "../machine/statements";
 import { valueTypes } from "../machine/values";
+import { literalTypes } from "../machine/literals";
 import skip from "./skip";
 import binding from "./binding";
 import sequence from "./sequence";
@@ -16,6 +17,7 @@ import byNeed from "./by_need";
 import number from "./number";
 import record from "./record";
 import procedure from "./procedure";
+import builtIn from "./built_in";
 
 export const printers = {
   statement: {
@@ -34,14 +36,15 @@ export const printers = {
     [statementTypes.byNeed]: byNeed,
   },
   literal: {
-    [valueTypes.number]: number,
-    [valueTypes.record]: record,
-    [valueTypes.procedure]: procedure,
+    [literalTypes.number]: number,
+    [literalTypes.record]: record,
+    [literalTypes.procedure]: procedure,
   },
   value: {
     [valueTypes.number]: number,
     [valueTypes.record]: record,
     [valueTypes.procedure]: procedure,
+    [valueTypes.builtIn]: builtIn,
   },
 };
 

--- a/app/oz/unification/index.js
+++ b/app/oz/unification/index.js
@@ -7,6 +7,7 @@ export const unificators = {
   [valueTypes.number]: number,
   [valueTypes.record]: record,
   [valueTypes.procedure]: procedure,
+  [valueTypes.builtIn]: procedure,
 };
 
 export const unifyValue = (

--- a/app/oz/value_creation/index.js
+++ b/app/oz/value_creation/index.js
@@ -1,12 +1,12 @@
-import { valueTypes } from "../machine/values";
+import { literalTypes } from "../machine/literals";
 import number from "./number";
 import record from "./record";
 import procedure from "./procedure";
 
 export const valueCreators = {
-  [valueTypes.number]: number,
-  [valueTypes.record]: record,
-  [valueTypes.procedure]: procedure,
+  [literalTypes.number]: number,
+  [literalTypes.record]: record,
+  [literalTypes.procedure]: procedure,
 };
 
 export const createValue = (environment, literal) => {

--- a/specs/compilation/index_spec.js
+++ b/specs/compilation/index_spec.js
@@ -1,7 +1,7 @@
 import Immutable from "immutable";
 import { compilers } from "../../app/oz/compilation";
 import { allStatementSyntaxTypes } from "../../app/oz/machine/statementSyntax";
-import { allValueTypes } from "../../app/oz/machine/values";
+import { allLiteralTypes } from "../../app/oz/machine/literals";
 
 describe("Compiling", () => {
   beforeEach(() => {
@@ -17,7 +17,7 @@ describe("Compiling", () => {
 
   it("has a compiler for all values", () => {
     const typesWithCompiler = Immutable.Set(Object.keys(compilers.literal));
-    const types = Immutable.Set(allValueTypes);
+    const types = Immutable.Set(allLiteralTypes);
 
     expect(typesWithCompiler).toEqual(types);
   });

--- a/specs/execution/builtin/float_spec.js
+++ b/specs/execution/builtin/float_spec.js
@@ -1,0 +1,177 @@
+import Immutable from "immutable";
+import {
+  skipStatement,
+  procedureApplicationStatement,
+} from "../../../app/oz/machine/statements";
+import {
+  lexicalIdentifier,
+  lexicalRecordSelection,
+} from "../../../app/oz/machine/lexical";
+import { literalAtom } from "../../../app/oz/machine/literals";
+import {
+  valueNumber,
+  valueBuiltIn,
+  valueAtom,
+} from "../../../app/oz/machine/values";
+import {
+  buildSingleThreadedState,
+  buildSemanticStatement,
+  buildSigma,
+  buildEquivalenceClass,
+  buildVariable,
+  buildEnvironment,
+} from "../../../app/oz/machine/build";
+import reduce from "../../../app/oz/execution/procedure_application";
+import { errorException } from "../../../app/oz/machine/exceptions";
+import { buildSystemExceptionState } from "../helpers";
+
+describe("Reducing {Float ...} builtin statements", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("handled float division correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Float", literalAtom("/")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(1.5), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled error when arguments in flaot division are not numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueAtom(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Float", literalAtom("/")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
+  it("handled float division by zero correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(0), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Float", literalAtom("/")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
+  it("handled number multipication as built in correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("/", "Float"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(1.5), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("/", "Float"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+});

--- a/specs/execution/builtin/number_spec.js
+++ b/specs/execution/builtin/number_spec.js
@@ -8,7 +8,7 @@ import {
   lexicalRecordSelection,
 } from "../../../app/oz/machine/lexical";
 import { literalAtom } from "../../../app/oz/machine/literals";
-import { valueNumber } from "../../../app/oz/machine/values";
+import { valueNumber, valueBuiltIn } from "../../../app/oz/machine/values";
 import {
   buildSingleThreadedState,
   buildSemanticStatement,
@@ -58,6 +58,50 @@ describe("Reducing {Number ...} builtin statements", () => {
         semanticStatements: [buildSemanticStatement(skipStatement())],
         sigma: buildSigma(
           buildEquivalenceClass(valueNumber(50), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled number plus as built in correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("+", "Number"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(50), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("+", "Number"),
+            buildVariable("o", 0),
+          ),
           buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
           buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
         ),

--- a/specs/execution/builtin/number_spec.js
+++ b/specs/execution/builtin/number_spec.js
@@ -30,7 +30,7 @@ describe("Reducing {Number ...} builtin statements", () => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  it("handled numberaddition correctly", () => {
+  it("handled number addition correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
@@ -403,7 +403,7 @@ describe("Reducing {Number ...} builtin statements", () => {
       buildSingleThreadedState({
         semanticStatements: [buildSemanticStatement(skipStatement())],
         sigma: buildSigma(
-          buildEquivalenceClass(valueNumber(1.5), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(1), buildVariable("c", 0)),
           buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
           buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
         ),
@@ -473,7 +473,7 @@ describe("Reducing {Number ...} builtin statements", () => {
     );
   });
 
-  it("handled number multipication as built in correctly", () => {
+  it("handled number division as built in correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
@@ -505,7 +505,7 @@ describe("Reducing {Number ...} builtin statements", () => {
       buildSingleThreadedState({
         semanticStatements: [buildSemanticStatement(skipStatement())],
         sigma: buildSigma(
-          buildEquivalenceClass(valueNumber(1.5), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(1), buildVariable("c", 0)),
           buildEquivalenceClass(
             valueBuiltIn("/", "Number"),
             buildVariable("o", 0),

--- a/specs/execution/builtin/number_spec.js
+++ b/specs/execution/builtin/number_spec.js
@@ -189,4 +189,87 @@ describe("Reducing {Number ...} builtin statements", () => {
       }),
     );
   });
+
+  it("handled number multiplication correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("*")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(600), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled number multipication as built in correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("*", "Number"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(600), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("*", "Number"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
 });

--- a/specs/execution/builtin/number_spec.js
+++ b/specs/execution/builtin/number_spec.js
@@ -51,8 +51,6 @@ describe("Reducing {Number ...} builtin statements", () => {
     );
 
     const result = reduce(state, statement, 0);
-    // eslint-disable-next-line no-console
-    console.log(result.toString());
     expect(result).toEqual(
       buildSingleThreadedState({
         semanticStatements: [buildSemanticStatement(skipStatement())],
@@ -100,6 +98,89 @@ describe("Reducing {Number ...} builtin statements", () => {
           buildEquivalenceClass(valueNumber(50), buildVariable("c", 0)),
           buildEquivalenceClass(
             valueBuiltIn("+", "Number"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled number minuscorrectly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("-")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(10), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled number minus built in correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("-", "Number"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(10), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("-", "Number"),
             buildVariable("o", 0),
           ),
           buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),

--- a/specs/execution/builtin/number_spec.js
+++ b/specs/execution/builtin/number_spec.js
@@ -1,0 +1,67 @@
+import Immutable from "immutable";
+import {
+  skipStatement,
+  procedureApplicationStatement,
+} from "../../../app/oz/machine/statements";
+import {
+  lexicalIdentifier,
+  lexicalRecordSelection,
+} from "../../../app/oz/machine/lexical";
+import { literalAtom } from "../../../app/oz/machine/literals";
+import { valueNumber } from "../../../app/oz/machine/values";
+import {
+  buildSingleThreadedState,
+  buildSemanticStatement,
+  buildSigma,
+  buildEquivalenceClass,
+  buildVariable,
+  buildEnvironment,
+} from "../../../app/oz/machine/build";
+import reduce from "../../../app/oz/execution/procedure_application";
+
+describe("Reducing {Number ...} builtin statements", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("handled numberplus correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("+")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    // eslint-disable-next-line no-console
+    console.log(result.toString());
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(50), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+});

--- a/specs/execution/builtin/number_spec.js
+++ b/specs/execution/builtin/number_spec.js
@@ -8,7 +8,11 @@ import {
   lexicalRecordSelection,
 } from "../../../app/oz/machine/lexical";
 import { literalAtom } from "../../../app/oz/machine/literals";
-import { valueNumber, valueBuiltIn } from "../../../app/oz/machine/values";
+import {
+  valueNumber,
+  valueBuiltIn,
+  valueAtom,
+} from "../../../app/oz/machine/values";
 import {
   buildSingleThreadedState,
   buildSemanticStatement,
@@ -18,13 +22,15 @@ import {
   buildEnvironment,
 } from "../../../app/oz/machine/build";
 import reduce from "../../../app/oz/execution/procedure_application";
+import { errorException } from "../../../app/oz/machine/exceptions";
+import { buildSystemExceptionState } from "../helpers";
 
 describe("Reducing {Number ...} builtin statements", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  it("handled numberplus correctly", () => {
+  it("handled numberaddition correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
@@ -63,7 +69,38 @@ describe("Reducing {Number ...} builtin statements", () => {
     );
   });
 
-  it("handled number plus as built in correctly", () => {
+  it("handled error when arguments in number addition are not numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueAtom(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("+")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
+  it("handled number addition as built in correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
@@ -107,7 +144,7 @@ describe("Reducing {Number ...} builtin statements", () => {
     );
   });
 
-  it("handled number minuscorrectly", () => {
+  it("handled number subtraction correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
@@ -146,7 +183,38 @@ describe("Reducing {Number ...} builtin statements", () => {
     );
   });
 
-  it("handled number minus built in correctly", () => {
+  it("handled error when arguments in number subtraction are not numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueAtom(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("-")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
+  it("handled number subtraction built in correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
@@ -229,6 +297,37 @@ describe("Reducing {Number ...} builtin statements", () => {
     );
   });
 
+  it("handled error when arguments in number multiplication are not numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueAtom(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("*")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
   it("handled number multipication as built in correctly", () => {
     const state = buildSingleThreadedState({
       semanticStatements: [buildSemanticStatement(skipStatement())],
@@ -264,6 +363,151 @@ describe("Reducing {Number ...} builtin statements", () => {
           buildEquivalenceClass(valueNumber(600), buildVariable("c", 0)),
           buildEquivalenceClass(
             valueBuiltIn("*", "Number"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled number division correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("/")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(1.5), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled error when arguments in number division are not numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueAtom(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("/")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
+  it("handled number division by zero correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(0), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Number", literalAtom("/")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSystemExceptionState(state, 0, errorException()),
+    );
+  });
+
+  it("handled number multipication as built in correctly", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("/", "Number"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueNumber(1.5), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("/", "Number"),
             buildVariable("o", 0),
           ),
           buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),

--- a/specs/execution/builtin/value_spec.js
+++ b/specs/execution/builtin/value_spec.js
@@ -1,0 +1,1026 @@
+import Immutable from "immutable";
+import {
+  skipStatement,
+  procedureApplicationStatement,
+} from "../../../app/oz/machine/statements";
+import {
+  lexicalIdentifier,
+  lexicalRecordSelection,
+} from "../../../app/oz/machine/lexical";
+import { literalAtom } from "../../../app/oz/machine/literals";
+import {
+  valueNumber,
+  valueBuiltIn,
+  valueBoolean,
+} from "../../../app/oz/machine/values";
+import {
+  buildSingleThreadedState,
+  buildSemanticStatement,
+  buildSigma,
+  buildEquivalenceClass,
+  buildVariable,
+  buildEnvironment,
+} from "../../../app/oz/machine/build";
+import reduce from "../../../app/oz/execution/procedure_application";
+
+describe("Reducing {Value ...} builtin statements", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("handled false correctly value equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("==")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false value equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("==", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("==", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true correctly value equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("==")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true value equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("==", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("==", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false correctly value non equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("\\=")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false value non equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("\\=", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("\\=", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true correctly value non equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("\\=")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true value non equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("\\=", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("\\=", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false correctly value less than or equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("=<")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false value less than or equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("=<", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("=<", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true correctly value less than or equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("=<")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true value less than or equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("=<", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("=<", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(20), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false correctly value less than comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("<")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false value less than comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("<", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("<", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true correctly value less than comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom("<")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true value less than comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn("<", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn("<", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false correctly value greater than or equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom(">=")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false value greater than or equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn(">=", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn(">=", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true correctly value greater than or equal comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom(">=")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true value greater than or equal comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn(">=", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn(">=", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false correctly value greater than comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom(">")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled false value greater than comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn(">", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(true), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn(">", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(30), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true correctly value greater than comparison between numbers", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(
+        lexicalRecordSelection("Value", literalAtom(">")),
+        [
+          lexicalIdentifier("A"),
+          lexicalIdentifier("B"),
+          lexicalIdentifier("C"),
+        ],
+      ),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    const result = reduce(state, statement, 0);
+    expect(result).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+
+  it("handled true value greater than comparison between numbers as builtin values", () => {
+    const state = buildSingleThreadedState({
+      semanticStatements: [buildSemanticStatement(skipStatement())],
+      sigma: buildSigma(
+        buildEquivalenceClass(undefined, buildVariable("c", 0)),
+        buildEquivalenceClass(
+          valueBuiltIn(">", "Value"),
+          buildVariable("o", 0),
+        ),
+        buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+        buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+      ),
+    });
+
+    const statement = buildSemanticStatement(
+      procedureApplicationStatement(lexicalIdentifier("O"), [
+        lexicalIdentifier("A"),
+        lexicalIdentifier("B"),
+        lexicalIdentifier("C"),
+      ]),
+      buildEnvironment({
+        C: buildVariable("c", 0),
+        O: buildVariable("o", 0),
+        A: buildVariable("a", 0),
+        B: buildVariable("b", 0),
+      }),
+    );
+
+    expect(reduce(state, statement, 0)).toEqual(
+      buildSingleThreadedState({
+        semanticStatements: [buildSemanticStatement(skipStatement())],
+        sigma: buildSigma(
+          buildEquivalenceClass(valueBoolean(false), buildVariable("c", 0)),
+          buildEquivalenceClass(
+            valueBuiltIn(">", "Value"),
+            buildVariable("o", 0),
+          ),
+          buildEquivalenceClass(valueNumber(19), buildVariable("a", 0)),
+          buildEquivalenceClass(valueNumber(20), buildVariable("b", 0)),
+        ),
+      }),
+    );
+  });
+});

--- a/specs/execution/index_spec.js
+++ b/specs/execution/index_spec.js
@@ -1,15 +1,25 @@
 import Immutable from "immutable";
 import { executors } from "../../app/oz/execution";
 import { allStatementTypes } from "../../app/oz/machine/statements";
+import { allBuiltInTypes } from "../../app/oz/machine/builtIns";
 
 describe("Executing statements", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  it("has an executor for all types", () => {
-    const typesWithReducers = Immutable.Set(Object.keys(executors));
+  it("has an executor for all statement types", () => {
+    const typesWithReducers = Immutable.Set(Object.keys(executors.statement));
     const types = Immutable.Set(allStatementTypes);
+
+    expect(typesWithReducers).toEqual(types);
+  });
+
+  it("has an executor for all builtin types", () => {
+    const typesWithReducers = Immutable.Set(
+      Object.keys(executors.value.builtIn),
+    );
+    const types = Immutable.Set(allBuiltInTypes);
 
     expect(typesWithReducers).toEqual(types);
   });

--- a/specs/execution/procedure_application_spec.js
+++ b/specs/execution/procedure_application_spec.js
@@ -222,7 +222,7 @@ describe("Reducing {X ...} statements", () => {
   describe("Reducing {Record.'.' ...} statements", () => {
     it("reduces correctly", () => {
       const state = buildSingleThreadedState({
-        semanticStatements: [],
+        semanticStatements: [buildSemanticStatement(skipStatement())],
         sigma: buildSigma(
           buildEquivalenceClass(undefined, buildVariable("c", 0)),
           buildEquivalenceClass(
@@ -253,7 +253,7 @@ describe("Reducing {X ...} statements", () => {
 
       expect(reduce(state, statement, 0)).toEqual(
         buildSingleThreadedState({
-          semanticStatements: [],
+          semanticStatements: [buildSemanticStatement(skipStatement())],
           sigma: buildSigma(
             buildEquivalenceClass(valueAtom("age"), buildVariable("f", 0)),
             buildEquivalenceClass(

--- a/specs/free_identifiers/index_spec.js
+++ b/specs/free_identifiers/index_spec.js
@@ -1,6 +1,7 @@
 import Immutable from "immutable";
 import { collectors } from "../../app/oz/free_identifiers";
 import { allStatementTypes } from "../../app/oz/machine/statements";
+import { allLiteralTypes } from "../../app/oz/machine/literals";
 import { allValueTypes } from "../../app/oz/machine/values";
 
 describe("Collecting free identifiers", () => {
@@ -21,8 +22,15 @@ describe("Collecting free identifiers", () => {
     const literalsWithCollectors = Immutable.Set(
       Object.keys(collectors.literal),
     );
-    const types = Immutable.Set(allValueTypes);
+    const types = Immutable.Set(allLiteralTypes);
 
     expect(literalsWithCollectors).toEqual(types);
+  });
+
+  it("has a collector for all values", () => {
+    const valuesWithCollectors = Immutable.Set(Object.keys(collectors.value));
+    const types = Immutable.Set(allValueTypes);
+
+    expect(valuesWithCollectors).toEqual(types);
   });
 });

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -17,7 +17,6 @@ describe("Validates initialization", () => {
     it("numberplus must be generated", () => {
       const environment = buildEnvironment({
         Number: buildVariable("number", 0),
-        Numberplus: buildVariable("numberplus", 0),
       });
       const sigma = buildSigma(
         buildEquivalenceClass(

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -13,11 +13,12 @@ describe("Validates initialization", () => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  describe("Number must exists in environment and in sigma", () => {
-    it("number must be generated", () => {
+  describe("Builtins must exists in environment and in sigma", () => {
+    it("all builtins must be generated", () => {
       const environment = buildEnvironment({
         Number: buildVariable("number", 0),
         Float: buildVariable("float", 0),
+        Value: buildVariable("value", 0),
       });
       const sigma = buildSigma(
         buildEquivalenceClass(
@@ -41,6 +42,30 @@ describe("Validates initialization", () => {
           buildVariable("floatdivision", 0),
         ),
         buildEquivalenceClass(
+          valueBuiltIn("==", "Value"),
+          buildVariable("valueequality", 0),
+        ),
+        buildEquivalenceClass(
+          valueBuiltIn("\\=", "Value"),
+          buildVariable("valuenonequality", 0),
+        ),
+        buildEquivalenceClass(
+          valueBuiltIn("=<", "Value"),
+          buildVariable("valuelessthanorequal", 0),
+        ),
+        buildEquivalenceClass(
+          valueBuiltIn("<", "Value"),
+          buildVariable("valuelessthan", 0),
+        ),
+        buildEquivalenceClass(
+          valueBuiltIn(">=", "Value"),
+          buildVariable("valuegreaterthanorequal", 0),
+        ),
+        buildEquivalenceClass(
+          valueBuiltIn(">", "Value"),
+          buildVariable("valuegreaterthan", 0),
+        ),
+        buildEquivalenceClass(
           valueRecord("Number", {
             "+": buildVariable("numberaddition", 0),
             "-": buildVariable("numbersubtraction", 0),
@@ -54,6 +79,17 @@ describe("Validates initialization", () => {
             "/": buildVariable("floatdivision", 0),
           }),
           buildVariable("float", 0),
+        ),
+        buildEquivalenceClass(
+          valueRecord("Value", {
+            "==": buildVariable("valueequality", 0),
+            "\\=": buildVariable("valuenonequality", 0),
+            "=<": buildVariable("valuelessthanorequal", 0),
+            "<": buildVariable("valuelessthan", 0),
+            ">=": buildVariable("valuegreaterthanorequal", 0),
+            ">": buildVariable("valuegreaterthan", 0),
+          }),
+          buildVariable("value", 0),
         ),
       );
 

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -28,9 +28,14 @@ describe("Validates initialization", () => {
           buildVariable("numberminus", 0),
         ),
         buildEquivalenceClass(
+          valueBuiltIn("*", "Number"),
+          buildVariable("numbermultiplication", 0),
+        ),
+        buildEquivalenceClass(
           valueRecord("Number", {
             "+": buildVariable("numberplus", 0),
             "-": buildVariable("numberminus", 0),
+            "*": buildVariable("numbermultiplication", 0),
           }),
           buildVariable("number", 0),
         ),

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -14,9 +14,10 @@ describe("Validates initialization", () => {
   });
 
   describe("Number must exists in environment and in sigma", () => {
-    it("numberplus must be generated", () => {
+    it("number must be generated", () => {
       const environment = buildEnvironment({
         Number: buildVariable("number", 0),
+        Float: buildVariable("float", 0),
       });
       const sigma = buildSigma(
         buildEquivalenceClass(
@@ -36,6 +37,10 @@ describe("Validates initialization", () => {
           buildVariable("numberdivision", 0),
         ),
         buildEquivalenceClass(
+          valueBuiltIn("/", "Float"),
+          buildVariable("floatdivision", 0),
+        ),
+        buildEquivalenceClass(
           valueRecord("Number", {
             "+": buildVariable("numberaddition", 0),
             "-": buildVariable("numbersubtraction", 0),
@@ -43,6 +48,12 @@ describe("Validates initialization", () => {
             "/": buildVariable("numberdivision", 0),
           }),
           buildVariable("number", 0),
+        ),
+        buildEquivalenceClass(
+          valueRecord("Float", {
+            "/": buildVariable("floatdivision", 0),
+          }),
+          buildVariable("float", 0),
         ),
       );
 

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -1,0 +1,36 @@
+import Immutable from "immutable";
+import {
+  buildSigma,
+  buildEquivalenceClass,
+  buildVariable,
+  buildEnvironment,
+} from "../../app/oz/machine/build";
+import { valueRecord, valueBuiltIn } from "../../app/oz/machine/values";
+import { initialize } from "../../app/oz/machine/initialization";
+
+describe("Validates initialization", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  describe("Number must exists in environment and in sigma", () => {
+    it("numberplus must be generated", () => {
+      const environment = buildEnvironment({
+        Number: buildVariable("number", 0),
+        Numberplus: buildVariable("numberplus", 0),
+      });
+      const sigma = buildSigma(
+        buildEquivalenceClass(
+          valueBuiltIn("+", "Number"),
+          buildVariable("numberplus", 0),
+        ),
+        buildEquivalenceClass(
+          valueRecord("Number", { "+": buildVariable("numberplus", 0) }),
+          buildVariable("number", 0),
+        ),
+      );
+
+      expect(initialize()).toEqual(Immutable.fromJS({ environment, sigma }));
+    });
+  });
+});

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -21,21 +21,26 @@ describe("Validates initialization", () => {
       const sigma = buildSigma(
         buildEquivalenceClass(
           valueBuiltIn("+", "Number"),
-          buildVariable("numberplus", 0),
+          buildVariable("numberaddition", 0),
         ),
         buildEquivalenceClass(
           valueBuiltIn("-", "Number"),
-          buildVariable("numberminus", 0),
+          buildVariable("numbersubtraction", 0),
         ),
         buildEquivalenceClass(
           valueBuiltIn("*", "Number"),
           buildVariable("numbermultiplication", 0),
         ),
         buildEquivalenceClass(
+          valueBuiltIn("/", "Number"),
+          buildVariable("numberdivision", 0),
+        ),
+        buildEquivalenceClass(
           valueRecord("Number", {
-            "+": buildVariable("numberplus", 0),
-            "-": buildVariable("numberminus", 0),
+            "+": buildVariable("numberaddition", 0),
+            "-": buildVariable("numbersubtraction", 0),
             "*": buildVariable("numbermultiplication", 0),
+            "/": buildVariable("numberdivision", 0),
           }),
           buildVariable("number", 0),
         ),

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -24,7 +24,14 @@ describe("Validates initialization", () => {
           buildVariable("numberplus", 0),
         ),
         buildEquivalenceClass(
-          valueRecord("Number", { "+": buildVariable("numberplus", 0) }),
+          valueBuiltIn("-", "Number"),
+          buildVariable("numberminus", 0),
+        ),
+        buildEquivalenceClass(
+          valueRecord("Number", {
+            "+": buildVariable("numberplus", 0),
+            "-": buildVariable("numberminus", 0),
+          }),
           buildVariable("number", 0),
         ),
       );

--- a/specs/print/builtIn_spec.js
+++ b/specs/print/builtIn_spec.js
@@ -1,0 +1,17 @@
+import Immutable from "immutable";
+import { print } from "../../app/oz/print";
+import { valueBuiltIn } from "../../app/oz/machine/values";
+
+describe("Printing a built in value", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("Returns the appropriate string when using inline values", () => {
+    const value = valueBuiltIn("+", "Number");
+    const result = print(value, 2);
+
+    expect(result.abbreviated).toEqual("  BuiltIn(Number.'+')");
+    expect(result.full).toEqual("  BuiltIn(Number.'+')");
+  });
+});

--- a/specs/print/index_spec.js
+++ b/specs/print/index_spec.js
@@ -1,6 +1,7 @@
 import Immutable from "immutable";
 import { printers } from "../../app/oz/print";
 import { allStatementTypes } from "../../app/oz/machine/statements";
+import { allLiteralTypes } from "../../app/oz/machine/literals";
 import { allValueTypes } from "../../app/oz/machine/values";
 
 describe("Printing", () => {
@@ -17,8 +18,15 @@ describe("Printing", () => {
 
   it("has a printer for all literals", () => {
     const literalsWithPrinters = Immutable.Set(Object.keys(printers.literal));
-    const literals = Immutable.Set(allValueTypes);
+    const literals = Immutable.Set(allLiteralTypes);
 
     expect(literalsWithPrinters).toEqual(literals);
+  });
+
+  it("has a printer for all values", () => {
+    const valuesWithPrinters = Immutable.Set(Object.keys(printers.value));
+    const values = Immutable.Set(allValueTypes);
+
+    expect(valuesWithPrinters).toEqual(values);
   });
 });

--- a/specs/value_creation/index_spec.js
+++ b/specs/value_creation/index_spec.js
@@ -1,6 +1,6 @@
 import Immutable from "immutable";
 import { valueCreators } from "../../app/oz/value_creation";
-import { allValueTypes } from "../../app/oz/machine/values";
+import { allLiteralTypes } from "../../app/oz/machine/literals";
 
 describe("Creating values", () => {
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe("Creating values", () => {
 
   it("has a value creator for all types", () => {
     const typesWithValueCreators = Immutable.Set(Object.keys(valueCreators));
-    const types = Immutable.Set(allValueTypes);
+    const types = Immutable.Set(allLiteralTypes);
 
     expect(typesWithValueCreators).toEqual(types);
   });


### PR DESCRIPTION
## Summary of changes

Implements the kernel syntax for value built in operations

* ```{Value.'==' X Y Z}```
* ```{Value.'\=' X Y Z}```
* ```{Value.'=<' X Y Z}```
* ```{Value.'<' X Y Z}```
* ```{Value.'>=' X Y Z}```
* ```{Value.'>' X Y Z}```

## Related issues

* Closes kozily/admin#86


