### PR TITLE
137 - Makes displaying system variables in sigma optional

### DIFF
--- a/app/oz/machine/build.js
+++ b/app/oz/machine/build.js
@@ -44,22 +44,23 @@ export const buildThread = ({
   });
 };
 
-export const buildVariable = (name, sequence) => {
+export const buildVariable = (name, sequence, { system = false } = {}) => {
   return Immutable.Map({
     name,
     sequence,
+    system,
   });
 };
 
 export const buildEquivalenceClass = (value, ...variables) => {
   return Immutable.Map({
     value,
-    variables: Immutable.Set(variables),
+    variables: Immutable.OrderedSet(variables),
   });
 };
 
 export const buildSigma = (...equivalenceClasses) => {
-  return Immutable.Set(equivalenceClasses);
+  return Immutable.OrderedSet(equivalenceClasses);
 };
 
 export const buildTrigger = (procedure, neededVariable) => {
@@ -70,7 +71,7 @@ export const buildTrigger = (procedure, neededVariable) => {
 };
 
 export const buildTau = (...triggers) => {
-  return Immutable.Set(triggers);
+  return Immutable.OrderedSet(triggers);
 };
 
 export const buildSingleThreadedState = ({
@@ -106,23 +107,28 @@ export const buildState = ({
 export const defaultEnvironment = () =>
   buildEnvironment(
     allBuiltInTypes.reduce((environment, builtInType) => {
-      const builtInTypeVariable = buildVariable(builtInType.toLowerCase(), 0);
+      const builtInTypeVariable = buildVariable(builtInType.toLowerCase(), 0, {
+        system: true,
+      });
 
       return environment.set(builtInType, builtInTypeVariable);
     }, buildEnvironment()),
   );
 
 export const defaultSigma = () =>
-  Immutable.Set(
+  Immutable.OrderedSet(
     allBuiltInTypes.reduce((sigma, builtInType) => {
       const builtInOperators = builtIns[builtInType];
-      const builtInTypeVariable = buildVariable(builtInType.toLowerCase(), 0);
+      const builtInTypeVariable = buildVariable(builtInType.toLowerCase(), 0, {
+        system: true,
+      });
 
       const features = Object.keys(builtInOperators).reduce(
         (acc, operatorKey) => {
           const operatorVariable = buildVariable(
             builtInOperators[operatorKey].name.toLowerCase(),
             0,
+            { system: true },
           );
           return acc.set(operatorKey, operatorVariable);
         },
@@ -139,6 +145,7 @@ export const defaultSigma = () =>
           const operatorVariable = buildVariable(
             builtInOperators[operatorKey].name.toLowerCase(),
             0,
+            { system: true },
           );
 
           const operatorValue = valueBuiltIn(operatorKey, builtInType);
@@ -153,7 +160,7 @@ export const defaultSigma = () =>
       return sigma
         .add(recordEquivalenceClass)
         .union(operatorsEquivalenceClasses);
-    }, Immutable.Set()),
+    }, Immutable.OrderedSet()),
   );
 
 export const buildFromKernelAST = ast => {

--- a/app/oz/machine/sigma.js
+++ b/app/oz/machine/sigma.js
@@ -1,4 +1,3 @@
-import Immutable from "immutable";
 import {
   buildVariable,
   makeAuxiliaryIdentifier,
@@ -33,7 +32,13 @@ export const isEquivalenceClassBound = equivalenceClass => {
 
 export const lookupVariableInSigma = (sigma, variable) => {
   return sigma.find(ec =>
-    ec.get("variables").some(x => Immutable.is(x, variable)),
+    ec
+      .get("variables")
+      .some(
+        x =>
+          x.get("name") === variable.get("name") &&
+          x.get("sequence") === variable.get("sequence"),
+      ),
   );
 };
 
@@ -41,7 +46,7 @@ export const mergeEquivalenceClasses = (sigma, target, source) => {
   const sourceVariables = source.get("variables");
 
   const mergedEquivalenceClass = target.update("variables", variables =>
-    variables.union(sourceVariables),
+    variables.concat(sourceVariables),
   );
 
   return sigma

--- a/app/state/runtime.js
+++ b/app/state/runtime.js
@@ -8,6 +8,7 @@ export const initialState = Immutable.fromJS({
   source: "",
   steps: [buildState()],
   currentStep: 0,
+  showSigmaSystemVariables: false,
 });
 
 export const run = () => {
@@ -40,6 +41,12 @@ export const previous = () => {
   };
 };
 
+export const toggleShowSigmaSystemVariables = () => {
+  return {
+    type: "RUNTIME_TOGGLE_SHOW_SIGMA_SYSTEM_VARIABLES",
+  };
+};
+
 export const reducer = (previousState = initialState, action) => {
   switch (action.type) {
     case "RUNTIME_RUN": {
@@ -69,6 +76,9 @@ export const reducer = (previousState = initialState, action) => {
     }
     case "CHANGE_SOURCE_CODE": {
       return previousState.set("source", action.payload);
+    }
+    case "RUNTIME_TOGGLE_SHOW_SIGMA_SYSTEM_VARIABLES": {
+      return previousState.update("showSigmaSystemVariables", value => !value);
     }
     default: {
       return previousState;

--- a/app/ui/runtime/stores/equivalence_class.jsx
+++ b/app/ui/runtime/stores/equivalence_class.jsx
@@ -2,10 +2,15 @@ import React from "react";
 import { List } from "semantic-ui-react";
 import Variable from "../variable";
 
-export const RuntimeStoresEquivalenceClass = ({ equivalenceClass }) => {
+export const RuntimeStoresEquivalenceClass = props => {
+  const allVariables = props.equivalenceClass.get("variables");
+  const variables = props.showSystemVariables
+    ? allVariables
+    : allVariables.filter(v => !v.get("system"));
+
   return (
     <List horizontal>
-      {equivalenceClass.get("variables").map((variable, index) => (
+      {variables.map((variable, index) => (
         <List.Item key={index}>
           <Variable variable={variable} />
         </List.Item>

--- a/app/ui/runtime/stores/index.jsx
+++ b/app/ui/runtime/stores/index.jsx
@@ -3,6 +3,7 @@ import { Segment, Header, Grid } from "semantic-ui-react";
 import { connect } from "react-redux";
 import Sigma from "./sigma";
 import Tau from "./tau";
+import { toggleShowSigmaSystemVariables } from "../../../state/runtime";
 
 export const RuntimeStores = props => {
   const sigma = props.machineState.get("sigma");
@@ -13,7 +14,13 @@ export const RuntimeStores = props => {
       <Header content="Stores" />
       <Grid columns="equal">
         <Grid.Column>
-          <Sigma store={sigma} />
+          <Sigma
+            store={sigma}
+            showSystemVariables={props.showSigmaSystemVariables}
+            onToggleShowSystemVariables={() =>
+              props.onToggleShowSigmaSystemVariable()
+            }
+          />
         </Grid.Column>
         <Grid.Column>
           <Tau store={tau} />
@@ -29,6 +36,15 @@ const mapStateToProps = state => ({
     "steps",
     state.getIn(["runtime", "currentStep"]),
   ]),
+  showSigmaSystemVariables: state.getIn([
+    "runtime",
+    "showSigmaSystemVariables",
+  ]),
 });
 
-export default connect(mapStateToProps)(RuntimeStores);
+const mapDispatchToProps = dispatch => ({
+  onToggleShowSigmaSystemVariable: () =>
+    dispatch(toggleShowSigmaSystemVariables()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(RuntimeStores);

--- a/app/ui/runtime/stores/sigma.jsx
+++ b/app/ui/runtime/stores/sigma.jsx
@@ -1,17 +1,17 @@
 import React from "react";
-import { Menu, Table, Popup } from "semantic-ui-react";
+import { Menu, Table, Popup, Dropdown } from "semantic-ui-react";
 import EquivalenceClass from "./equivalence_class";
 import Code from "../code";
 import { print } from "../../../oz/print";
 
-export const RuntimeStoreRow = ({ equivalenceClass }) => {
-  const value = equivalenceClass.get("value");
+export const RuntimeStoreRow = props => {
+  const value = props.equivalenceClass.get("value");
 
   if (!value) {
     return (
       <Table.Row>
         <Table.Cell>
-          <EquivalenceClass equivalenceClass={equivalenceClass} />
+          <EquivalenceClass {...props} />
         </Table.Cell>
         <Table.Cell>
           <Code>Unbound</Code>
@@ -21,40 +21,65 @@ export const RuntimeStoreRow = ({ equivalenceClass }) => {
   }
 
   const printedValue = print(value);
-  const content = (
-    <Table.Row>
-      <Table.Cell>
-        <EquivalenceClass equivalenceClass={equivalenceClass} />
-      </Table.Cell>
-      <Table.Cell>
-        <Code>{printedValue.abbreviated}</Code>
-      </Table.Cell>
-    </Table.Row>
-  );
 
   return (
-    <Popup wide hoverable trigger={content}>
+    <Popup
+      wide
+      hoverable
+      trigger={
+        <Table.Row>
+          <Table.Cell>
+            <EquivalenceClass {...props} />
+          </Table.Cell>
+          <Table.Cell>
+            <Code>{printedValue.abbreviated}</Code>
+          </Table.Cell>
+        </Table.Row>
+      }
+    >
       <pre>{printedValue.full}</pre>
     </Popup>
   );
 };
 
 export const RuntimeStoresSigma = props => {
+  const showHide = props.showSystemVariables ? "Hide" : "Show";
+  const showHideMessage = `${showHide} system variables`;
+  const equivalenceClasses = props.showSystemVariables
+    ? props.store
+    : props.store.filter(ec => ec.get("variables").some(v => !v.get("system")));
+  const orderedEquivalenceClasses = equivalenceClasses.reverse();
+
   return (
     <div>
       <Menu borderless attached="top" size="tiny">
         <Menu.Item header content={"Immutable (\u03c3)"} />
+        <Menu.Menu position="right">
+          <Dropdown item icon="ellipsis vertical">
+            <Dropdown.Menu>
+              <Dropdown.Item
+                icon="cubes"
+                content={showHideMessage}
+                onClick={props.onToggleShowSystemVariables}
+              />
+            </Dropdown.Menu>
+          </Dropdown>
+        </Menu.Menu>
       </Menu>
       <Table attached selectable compact>
         <Table.Header>
           <Table.Row>
-            <Table.HeaderCell>Variable</Table.HeaderCell>
+            <Table.HeaderCell>Variables</Table.HeaderCell>
             <Table.HeaderCell>Value</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
         <Table.Body>
-          {props.store.map((equivalenceClass, index) => (
-            <RuntimeStoreRow key={index} equivalenceClass={equivalenceClass} />
+          {orderedEquivalenceClasses.map((equivalenceClass, index) => (
+            <RuntimeStoreRow
+              key={index}
+              equivalenceClass={equivalenceClass}
+              showSystemVariables={props.showSystemVariables}
+            />
           ))}
         </Table.Body>
       </Table>

--- a/specs/execution/binding_spec.js
+++ b/specs/execution/binding_spec.js
@@ -88,15 +88,15 @@ describe("Reducing X=Y statements", () => {
         sigma: buildSigma(
           buildEquivalenceClass(
             undefined,
+            buildVariable("z", 0),
+            buildVariable("z", 1),
+          ),
+          buildEquivalenceClass(
+            undefined,
             buildVariable("x", 0),
             buildVariable("x", 1),
             buildVariable("y", 0),
             buildVariable("y", 1),
-          ),
-          buildEquivalenceClass(
-            undefined,
-            buildVariable("z", 0),
-            buildVariable("z", 1),
           ),
         ),
       }),
@@ -136,15 +136,15 @@ describe("Reducing X=Y statements", () => {
         sigma: buildSigma(
           buildEquivalenceClass(
             undefined,
+            buildVariable("z", 0),
+            buildVariable("z", 1),
+          ),
+          buildEquivalenceClass(
+            undefined,
             buildVariable("x", 0),
             buildVariable("x", 1),
             buildVariable("y", 0),
             buildVariable("y", 1),
-          ),
-          buildEquivalenceClass(
-            undefined,
-            buildVariable("z", 0),
-            buildVariable("z", 1),
           ),
         ),
       }),

--- a/specs/execution/value_creation_spec.js
+++ b/specs/execution/value_creation_spec.js
@@ -84,14 +84,14 @@ describe("Reducing X=VALUE statements", () => {
         buildSingleThreadedState({
           sigma: buildSigma(
             buildEquivalenceClass(
-              valueNumber(155),
-              buildVariable("x", 0),
-              buildVariable("x", 1),
-            ),
-            buildEquivalenceClass(
               undefined,
               buildVariable("y", 0),
               buildVariable("y", 1),
+            ),
+            buildEquivalenceClass(
+              valueNumber(155),
+              buildVariable("x", 0),
+              buildVariable("x", 1),
             ),
           ),
         }),
@@ -131,13 +131,13 @@ describe("Reducing X=VALUE statements", () => {
         buildSingleThreadedState({
           sigma: buildSigma(
             buildEquivalenceClass(
+              valueRecord("person", { age: buildVariable("a", 0) }),
+              buildVariable("p", 0),
+            ),
+            buildEquivalenceClass(
               undefined,
               buildVariable("x", 0),
               buildVariable("a", 0),
-            ),
-            buildEquivalenceClass(
-              valueRecord("person", { age: buildVariable("a", 0) }),
-              buildVariable("p", 0),
             ),
           ),
         }),
@@ -175,13 +175,13 @@ describe("Reducing X=VALUE statements", () => {
         buildSingleThreadedState({
           sigma: buildSigma(
             buildEquivalenceClass(
-              valueNumber(3),
-              buildVariable("x", 0),
-              buildVariable("a", 0),
-            ),
-            buildEquivalenceClass(
               valueRecord("person", { age: buildVariable("a", 0) }),
               buildVariable("p", 0),
+            ),
+            buildEquivalenceClass(
+              valueNumber(3),
+              buildVariable("a", 0),
+              buildVariable("x", 0),
             ),
           ),
         }),

--- a/specs/machine/initialization_spec.js
+++ b/specs/machine/initialization_spec.js
@@ -9,7 +9,9 @@ import { lookupVariableInSigma } from "../../app/oz/machine/sigma";
 import { valueRecord, valueBuiltIn } from "../../app/oz/machine/values";
 
 const lookupBuiltInInSigma = (sigma, builtIn) =>
-  lookupVariableInSigma(sigma, buildVariable(builtIn, 0)).get("value");
+  lookupVariableInSigma(sigma, buildVariable(builtIn, 0, { system: true })).get(
+    "value",
+  );
 
 describe("State initialization", () => {
   beforeEach(() => {
@@ -20,10 +22,10 @@ describe("State initialization", () => {
     const state = buildFromKernelAST(skipStatement());
 
     const environment = buildEnvironment({
-      Number: buildVariable("number", 0),
-      Float: buildVariable("float", 0),
-      Record: buildVariable("record", 0),
-      Value: buildVariable("value", 0),
+      Number: buildVariable("number", 0, { system: true }),
+      Float: buildVariable("float", 0, { system: true }),
+      Record: buildVariable("record", 0, { system: true }),
+      Value: buildVariable("value", 0, { system: true }),
     });
 
     expect(state.getIn(["threads", 0, "stack", 0, "environment"])).toEqual(
@@ -37,11 +39,11 @@ describe("State initialization", () => {
 
     expect(lookupBuiltInInSigma(sigma, "number")).toEqual(
       valueRecord("Number", {
-        "+": buildVariable("nsum", 0),
-        "-": buildVariable("nsub", 0),
-        "*": buildVariable("nmul", 0),
-        div: buildVariable("ndiv", 0),
-        mod: buildVariable("nmod", 0),
+        "+": buildVariable("nsum", 0, { system: true }),
+        "-": buildVariable("nsub", 0, { system: true }),
+        "*": buildVariable("nmul", 0, { system: true }),
+        div: buildVariable("ndiv", 0, { system: true }),
+        mod: buildVariable("nmod", 0, { system: true }),
       }),
     );
     expect(lookupBuiltInInSigma(sigma, "nsum")).toEqual(
@@ -67,7 +69,7 @@ describe("State initialization", () => {
 
     expect(lookupBuiltInInSigma(sigma, "float")).toEqual(
       valueRecord("Float", {
-        "/": buildVariable("fdiv", 0),
+        "/": buildVariable("fdiv", 0, { system: true }),
       }),
     );
     expect(lookupBuiltInInSigma(sigma, "fdiv")).toEqual(
@@ -81,7 +83,7 @@ describe("State initialization", () => {
 
     expect(lookupBuiltInInSigma(sigma, "record")).toEqual(
       valueRecord("Record", {
-        ".": buildVariable("rsel", 0),
+        ".": buildVariable("rsel", 0, { system: true }),
       }),
     );
     expect(lookupBuiltInInSigma(sigma, "rsel")).toEqual(
@@ -95,12 +97,12 @@ describe("State initialization", () => {
 
     expect(lookupBuiltInInSigma(sigma, "value")).toEqual(
       valueRecord("Value", {
-        "==": buildVariable("veq", 0),
-        "\\=": buildVariable("vneq", 0),
-        "<": buildVariable("vlt", 0),
-        "<=": buildVariable("vle", 0),
-        ">": buildVariable("vgt", 0),
-        ">=": buildVariable("vge", 0),
+        "==": buildVariable("veq", 0, { system: true }),
+        "\\=": buildVariable("vneq", 0, { system: true }),
+        "<": buildVariable("vlt", 0, { system: true }),
+        "<=": buildVariable("vle", 0, { system: true }),
+        ">": buildVariable("vgt", 0, { system: true }),
+        ">=": buildVariable("vge", 0, { system: true }),
       }),
     );
     expect(lookupBuiltInInSigma(sigma, "veq")).toEqual(

--- a/specs/machine/store/unify_spec.js
+++ b/specs/machine/store/unify_spec.js
@@ -64,8 +64,8 @@ describe("Unifying values in the sigma", () => {
       const unifiedSigma = buildSigma(
         buildEquivalenceClass(
           valueNumber(100),
-          buildVariable("x", 0),
           buildVariable("y", 0),
+          buildVariable("x", 0),
         ),
       );
 

--- a/specs/unification/record_spec.js
+++ b/specs/unification/record_spec.js
@@ -33,16 +33,16 @@ describe("Unifying records", () => {
 
     const unifiedSigma = buildSigma(
       buildEquivalenceClass(
+        undefined,
+        buildVariable("y", 0),
+        buildVariable("y", 1),
+      ),
+      buildEquivalenceClass(
         valueRecord("person", { name: buildVariable("y", 0) }),
         buildVariable("x", 0),
         buildVariable("x", 1),
         buildVariable("z", 0),
         buildVariable("z", 1),
-      ),
-      buildEquivalenceClass(
-        undefined,
-        buildVariable("y", 0),
-        buildVariable("y", 1),
       ),
     );
 
@@ -73,17 +73,17 @@ describe("Unifying records", () => {
 
     const unifiedSigma = buildSigma(
       buildEquivalenceClass(
+        undefined,
+        buildVariable("y", 0),
+        buildVariable("y", 1),
+        buildVariable("w", 0),
+      ),
+      buildEquivalenceClass(
         valueRecord("person", { name: buildVariable("y", 0) }),
         buildVariable("x", 0),
         buildVariable("x", 1),
         buildVariable("z", 0),
         buildVariable("z", 1),
-      ),
-      buildEquivalenceClass(
-        undefined,
-        buildVariable("y", 0),
-        buildVariable("y", 1),
-        buildVariable("w", 0),
       ),
     );
 
@@ -120,10 +120,9 @@ describe("Unifying records", () => {
 
     const unifiedSigma = buildSigma(
       buildEquivalenceClass(
-        valueRecord("person", { address: buildVariable("y", 0) }),
-        buildVariable("x", 0),
-        buildVariable("x", 1),
-        buildVariable("z", 0),
+        undefined,
+        buildVariable("a", 0),
+        buildVariable("b", 0),
       ),
       buildEquivalenceClass(
         valueRecord("address", { street: buildVariable("a", 0) }),
@@ -131,9 +130,10 @@ describe("Unifying records", () => {
         buildVariable("p", 0),
       ),
       buildEquivalenceClass(
-        undefined,
-        buildVariable("a", 0),
-        buildVariable("b", 0),
+        valueRecord("person", { address: buildVariable("y", 0) }),
+        buildVariable("x", 0),
+        buildVariable("x", 1),
+        buildVariable("z", 0),
       ),
     );
 


### PR DESCRIPTION
## Summary of changes

* Makes the equivalence class variable set and sigma equivalence class set both ordered sets, so that they retain the original insertion order
* Variables now have a system field (false by default) which indicates that a variable is a system variable. System variables are hidden by default, and can be show by clicking on a setting on sigma.

## Related issues

* Closes kozily/admin#137
