### PR TITLE
131 - Checks free identifiers when parsing to detect undeclared identifiers

### DIFF
--- a/app/oz/free_identifiers/index.js
+++ b/app/oz/free_identifiers/index.js
@@ -1,3 +1,4 @@
+import Immutable from "immutable";
 import { statementTypes } from "../machine/statements";
 import { literalTypes } from "../machine/literals";
 import { expressionTypes } from "../machine/expressions";
@@ -50,6 +51,9 @@ export const collectors = {
 };
 
 export const collectFreeIdentifiers = node => {
+  if (!node) {
+    return Immutable.Set();
+  }
   const collector = collectors[node.get("node")][node.get("type")];
   return collector(collectFreeIdentifiers, node);
 };


### PR DESCRIPTION
## Summary of changes

The parse reducer now checks for free identifiers to display a parse error if there are undeclared identifiers in the program.

## Related issues

* Closes kozily/admin#131
