### PR TITLE
139 - Changes by need thread variable identifiers

### DIFF
--- a/app/oz/execution/by_need.js
+++ b/app/oz/execution/by_need.js
@@ -1,8 +1,10 @@
 import { lookupVariableInSigma } from "../machine/sigma";
+import { lexicalIdentifier } from "../machine/lexical";
 import {
   buildThread,
   buildSemanticStatement,
   buildTrigger,
+  buildEnvironment,
 } from "../machine/build";
 import { procedureApplicationStatement } from "../machine/statements";
 
@@ -23,15 +25,31 @@ export default function(state, semanticStatement) {
   );
 
   if (neededEquivalenceClass.get("value")) {
-    const newStatement = procedureApplicationStatement(procedure, [needed]);
+    const newStatement = procedureApplicationStatement(
+      lexicalIdentifier("TriggerProcedure"),
+      [needed],
+    );
     const newThread = buildThread({
-      semanticStatements: [buildSemanticStatement(newStatement, environment)],
+      semanticStatements: [
+        buildSemanticStatement(
+          newStatement,
+          buildEnvironment({
+            TriggerProcedure: procedureVariable,
+            [neededIdentifier]: neededVariable,
+          }),
+        ),
+      ],
     });
 
     return state.update("threads", threads => threads.push(newThread));
   }
 
-  const newTrigger = buildTrigger(procedureVariable, neededVariable);
+  const newTrigger = buildTrigger(
+    procedureVariable,
+    "TriggerProcedure",
+    neededVariable,
+    neededIdentifier,
+  );
 
   return state.update("tau", tau => tau.add(newTrigger));
 }

--- a/app/oz/machine/build.js
+++ b/app/oz/machine/build.js
@@ -63,10 +63,17 @@ export const buildSigma = (...equivalenceClasses) => {
   return Immutable.OrderedSet(equivalenceClasses);
 };
 
-export const buildTrigger = (procedure, neededVariable) => {
+export const buildTrigger = (
+  procedure,
+  procedureIdentifier,
+  neededVariable,
+  neededVariableIdentifier,
+) => {
   return Immutable.fromJS({
     procedure,
+    procedureIdentifier,
     neededVariable,
+    neededVariableIdentifier,
   });
 };
 

--- a/app/oz/machine/threads.js
+++ b/app/oz/machine/threads.js
@@ -50,12 +50,15 @@ export const processWaitConditions = state => {
 };
 
 export const activateTrigger = (state, trigger) => {
-  const statement = procedureApplicationStatement(lexicalIdentifier("X"), [
-    lexicalIdentifier("Y"),
-  ]);
+  const procedureIdentifier = trigger.get("procedureIdentifier");
+  const neededVariableIdentifier = trigger.get("neededVariableIdentifier");
+  const statement = procedureApplicationStatement(
+    lexicalIdentifier(procedureIdentifier),
+    [lexicalIdentifier(neededVariableIdentifier)],
+  );
   const environment = buildEnvironment({
-    X: trigger.get("procedure"),
-    Y: trigger.get("neededVariable"),
+    [procedureIdentifier]: trigger.get("procedure"),
+    [neededVariableIdentifier]: trigger.get("neededVariable"),
   });
 
   const newThread = buildThread({

--- a/specs/execution/by_need_spec.js
+++ b/specs/execution/by_need_spec.js
@@ -30,15 +30,15 @@ describe("Reducing by need statements", () => {
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
         buildEquivalenceClass(undefined, buildVariable("x", 0)),
-        buildEquivalenceClass(undefined, buildVariable("y", 0)),
+        buildEquivalenceClass(undefined, buildVariable("w", 0)),
       ),
     });
 
     const statement = buildSemanticStatement(
-      byNeedStatement(lexicalIdentifier("X"), lexicalIdentifier("Y")),
+      byNeedStatement(lexicalIdentifier("X"), lexicalIdentifier("W")),
       buildEnvironment({
         X: buildVariable("x", 0),
-        Y: buildVariable("y", 0),
+        W: buildVariable("w", 0),
       }),
     );
 
@@ -47,7 +47,12 @@ describe("Reducing by need statements", () => {
         semanticStatements: [buildSemanticStatement(skipStatement())],
         sigma: state.get("sigma"),
         tau: buildTau(
-          buildTrigger(buildVariable("x", 0), buildVariable("y", 0)),
+          buildTrigger(
+            buildVariable("x", 0),
+            "TriggerProcedure",
+            buildVariable("w", 0),
+            "W",
+          ),
         ),
       }),
     );
@@ -58,15 +63,15 @@ describe("Reducing by need statements", () => {
       semanticStatements: [buildSemanticStatement(skipStatement())],
       sigma: buildSigma(
         buildEquivalenceClass(undefined, buildVariable("x", 0)),
-        buildEquivalenceClass(valueNumber(5), buildVariable("y", 0)),
+        buildEquivalenceClass(valueNumber(5), buildVariable("w", 0)),
       ),
     });
 
     const statement = buildSemanticStatement(
-      byNeedStatement(lexicalIdentifier("X"), lexicalIdentifier("Y")),
+      byNeedStatement(lexicalIdentifier("X"), lexicalIdentifier("W")),
       buildEnvironment({
         X: buildVariable("x", 0),
-        Y: buildVariable("y", 0),
+        W: buildVariable("w", 0),
       }),
     );
 
@@ -80,10 +85,14 @@ describe("Reducing by need statements", () => {
           buildThread({
             semanticStatements: [
               buildSemanticStatement(
-                procedureApplicationStatement(lexicalIdentifier("X"), [
-                  lexicalIdentifier("Y"),
-                ]),
-                statement.get("environment"),
+                procedureApplicationStatement(
+                  lexicalIdentifier("TriggerProcedure"),
+                  [lexicalIdentifier("W")],
+                ),
+                buildEnvironment({
+                  TriggerProcedure: buildVariable("x", 0),
+                  W: buildVariable("w", 0),
+                }),
               ),
             ],
           }),

--- a/specs/machine/threads/process_triggers_spec.js
+++ b/specs/machine/threads/process_triggers_spec.js
@@ -49,7 +49,14 @@ describe("threads#processTriggers", () => {
           buildVariable("p", 0),
         ),
       ),
-      tau: buildTau(buildTrigger(buildVariable("p", 0), buildVariable("x", 0))),
+      tau: buildTau(
+        buildTrigger(
+          buildVariable("p", 0),
+          "TriggerProcedure",
+          buildVariable("x", 0),
+          "X",
+        ),
+      ),
     });
 
     expect(processTriggers(state)).toEqual(state);
@@ -68,7 +75,14 @@ describe("threads#processTriggers", () => {
           buildVariable("p", 0),
         ),
       ),
-      tau: buildTau(buildTrigger(buildVariable("p", 0), buildVariable("x", 0))),
+      tau: buildTau(
+        buildTrigger(
+          buildVariable("p", 0),
+          "TriggerProcedure",
+          buildVariable("x", 0),
+          "X",
+        ),
+      ),
     });
 
     expect(processTriggers(state)).toEqual(
@@ -80,12 +94,13 @@ describe("threads#processTriggers", () => {
           buildThread({
             semanticStatements: [
               buildSemanticStatement(
-                procedureApplicationStatement(lexicalIdentifier("X"), [
-                  lexicalIdentifier("Y"),
-                ]),
+                procedureApplicationStatement(
+                  lexicalIdentifier("TriggerProcedure"),
+                  [lexicalIdentifier("X")],
+                ),
                 buildEnvironment({
-                  X: buildVariable("p", 0),
-                  Y: buildVariable("x", 0),
+                  TriggerProcedure: buildVariable("p", 0),
+                  X: buildVariable("x", 0),
                 }),
               ),
             ],
@@ -113,7 +128,14 @@ describe("threads#processTriggers", () => {
           buildVariable("p", 0),
         ),
       ),
-      tau: buildTau(buildTrigger(buildVariable("p", 0), buildVariable("x", 0))),
+      tau: buildTau(
+        buildTrigger(
+          buildVariable("p", 0),
+          "TriggerProcedure",
+          buildVariable("x", 0),
+          "X",
+        ),
+      ),
     });
 
     expect(processTriggers(state)).toEqual(
@@ -129,12 +151,13 @@ describe("threads#processTriggers", () => {
           buildThread({
             semanticStatements: [
               buildSemanticStatement(
-                procedureApplicationStatement(lexicalIdentifier("X"), [
-                  lexicalIdentifier("Y"),
-                ]),
+                procedureApplicationStatement(
+                  lexicalIdentifier("TriggerProcedure"),
+                  [lexicalIdentifier("X")],
+                ),
                 buildEnvironment({
-                  X: buildVariable("p", 0),
-                  Y: buildVariable("x", 0),
+                  TriggerProcedure: buildVariable("p", 0),
+                  X: buildVariable("x", 0),
                 }),
               ),
             ],


### PR DESCRIPTION
## Summary of changes

By need triggers, when activate, now use the name `TriggerProcedure` for the procedure identifier, and the original variable name declared on the `ByNeed` statement as the variable name.

## Related issues

* Closes kozily/admin#139