### PR TITLE
140 - Implements compiler for conditionals without else

### DIFF
--- a/app/oz/compilation/conditional.js
+++ b/app/oz/compilation/conditional.js
@@ -1,12 +1,16 @@
-import { conditionalStatement } from "../machine/statements";
+import { conditionalStatement, skipStatement } from "../machine/statements";
 
 export default (recurse, statement) => {
-  const trueStatement = recurse(statement.get("trueStatement"));
-  const falseStatement = recurse(statement.get("falseStatement"));
+  const compiledTrueStatement = recurse(statement.get("trueStatement"));
+
+  const falseStatement = statement.get("falseStatement");
+  const compiledFalseStatement = falseStatement
+    ? recurse(falseStatement)
+    : skipStatement();
 
   return conditionalStatement(
     statement.get("condition"),
-    trueStatement,
-    falseStatement,
+    compiledTrueStatement,
+    compiledFalseStatement,
   );
 };

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -91,14 +91,14 @@ stm_value_creation -> ids_identifier _ "=" _ exp_expression {%
   }
 %}
 
-stm_conditional -> "if" __ ids_identifier __ "then" __ stm_sequence __ "else" __ stm_sequence __ "end" {%
+stm_conditional -> "if" __ ids_identifier __ "then" __ stm_sequence __ ("else" __ stm_sequence __):? "end" {%
   function(d, position, reject) {
     return {
       node: "statement",
       type: "conditionalSyntax",
       condition: d[2],
       trueStatement: d[6],
-      falseStatement: d[10],
+      falseStatement: d[8] ? d[8][2] : undefined,
     }
   }
 %}

--- a/specs/compilation/conditional_spec.js
+++ b/specs/compilation/conditional_spec.js
@@ -3,10 +3,12 @@ import { compile } from "../../app/oz/compilation";
 import {
   conditionalStatementSyntax,
   skipStatementSyntax,
+  bindingStatementSyntax,
 } from "../../app/oz/machine/statementSyntax";
 import {
   conditionalStatement,
   skipStatement,
+  bindingStatement,
 } from "../../app/oz/machine/statements";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
@@ -26,6 +28,21 @@ describe("Compiling conditional statements", () => {
       conditionalStatement(
         lexicalIdentifier("X"),
         skipStatement(),
+        skipStatement(),
+      ),
+    );
+  });
+
+  it("compiles appropriately conditionals without else", () => {
+    const statement = conditionalStatementSyntax(
+      lexicalIdentifier("X"),
+      bindingStatementSyntax(lexicalIdentifier("A"), lexicalIdentifier("B")),
+    );
+
+    expect(compile(statement)).toEqual(
+      conditionalStatement(
+        lexicalIdentifier("X"),
+        bindingStatement(lexicalIdentifier("A"), lexicalIdentifier("B")),
         skipStatement(),
       ),
     );

--- a/specs/parser/statements/conditional_spec.js
+++ b/specs/parser/statements/conditional_spec.js
@@ -13,25 +13,19 @@ describe("Parsing conditional statements", () => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  describe("when condition is a variable", () => {
-    it("when is composed by two statement in the true statement", () => {
-      expect(parse("if X then skip skip else skip end")).toEqual(
-        conditionalStatementSyntax(
-          lexicalIdentifier("X"),
-          sequenceStatementSyntax(skipStatementSyntax(), skipStatementSyntax()),
-          skipStatementSyntax(),
-        ),
-      );
-    });
+  it("parses simple if ... then ... else ... end statements", () => {
+    expect(parse("if X then skip skip else skip end")).toEqual(
+      conditionalStatementSyntax(
+        lexicalIdentifier("X"),
+        sequenceStatementSyntax(skipStatementSyntax(), skipStatementSyntax()),
+        skipStatementSyntax(),
+      ),
+    );
+  });
 
-    it("when is composed by two statements in the false statement", () => {
-      expect(parse("if X then skip else skip skip end")).toEqual(
-        conditionalStatementSyntax(
-          lexicalIdentifier("X"),
-          skipStatementSyntax(),
-          sequenceStatementSyntax(skipStatementSyntax(), skipStatementSyntax()),
-        ),
-      );
-    });
+  it("parses simple if ... then ... end statements", () => {
+    expect(parse("if X then skip end")).toEqual(
+      conditionalStatementSyntax(lexicalIdentifier("X"), skipStatementSyntax()),
+    );
   });
 });


### PR DESCRIPTION
## Summary of changes

The else part of the conditional statement syntax is now optional, and is compiled to an `else skip` if not provided.

## Related issues

* Closes kozily/admin#140
