### PR TITLE
96 - Implements the full syntax for case statements

### DIFF
--- a/app/oz/compilation/pattern_matching.js
+++ b/app/oz/compilation/pattern_matching.js
@@ -1,14 +1,18 @@
-import { patternMatchingStatement } from "../machine/statements";
+import { patternMatchingStatement, skipStatement } from "../machine/statements";
 
 export default (recurse, statement) => {
-  const pattern = statement.get("pattern");
-  const trueStatement = recurse(statement.get("trueStatement"));
-  const falseStatement = recurse(statement.get("falseStatement"));
+  const identifier = statement.get("identifier");
+  const falseStatement = statement.get("falseStatement");
+  const finalFalseStatement = falseStatement
+    ? recurse(statement.get("falseStatement"))
+    : skipStatement();
 
-  return patternMatchingStatement(
-    statement.get("identifier"),
-    pattern,
-    trueStatement,
-    falseStatement,
-  );
+  return statement.get("clauses").reduceRight((result, clause) => {
+    return patternMatchingStatement(
+      identifier,
+      clause.get("pattern"),
+      recurse(clause.get("statement")),
+      result,
+    );
+  }, finalFalseStatement);
 };

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -103,15 +103,22 @@ stm_conditional -> "if" __ exp_expression __ "then" __ stm_sequence __ ("else" _
   }
 %}
 
-stm_pattern_matching -> "case" __ exp_expression __ "of" __ lit_record_like __ "then" __ stm_sequence __ "else" __ stm_sequence __ "end" {%
+stm_pattern_matching -> "case" __ exp_expression __ "of" __ lit_record_like __ "then" __ stm_sequence __ ("[]" __ lit_record_like __ "then" __ stm_sequence __ ):* ("else" __ stm_sequence __):? "end" {%
   function(d, position, reject) {
+    const clauses = d[12].reduce(function(result, clause) {
+      result.push({
+        pattern: clause[2],
+        statement: clause[6],
+      });
+      return result;
+    }, [{pattern: d[6], statement: d[10]}]);
+
     return {
       node: "statement",
       type: "patternMatchingSyntax",
       identifier: d[2],
-      pattern: d[6],
-      trueStatement: d[10],
-      falseStatement: d[14],
+      clauses: clauses,
+      falseStatement: d[13] ? d[13][2] : undefined,
     }
   }
 %}

--- a/app/oz/machine/statementSyntax.js
+++ b/app/oz/machine/statementSyntax.js
@@ -76,16 +76,14 @@ export const conditionalStatementSyntax = (
 
 export const patternMatchingStatementSyntax = (
   identifier,
-  pattern,
-  trueStatement,
+  clauses,
   falseStatement = undefined,
 ) => {
-  return new Immutable.Map({
+  return new Immutable.fromJS({
     node: "statement",
     type: statementSyntaxTypes.patternMatchingSyntax,
     identifier,
-    pattern,
-    trueStatement,
+    clauses,
     falseStatement,
   });
 };

--- a/specs/compilation/pattern_matching_spec.js
+++ b/specs/compilation/pattern_matching_spec.js
@@ -4,10 +4,12 @@ import { identifierExpression } from "../../app/oz/machine/expressions";
 import {
   patternMatchingStatementSyntax,
   skipStatementSyntax,
+  bindingStatementSyntax,
 } from "../../app/oz/machine/statementSyntax";
 import {
   patternMatchingStatement,
   skipStatement,
+  bindingStatement,
 } from "../../app/oz/machine/statements";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 import { literalRecord } from "../../app/oz/machine/literals";
@@ -17,11 +19,15 @@ describe("Compiling patternMatching statements", () => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  it("compiles appropriately", () => {
+  it("compiles appropriately simple cases", () => {
     const statement = patternMatchingStatementSyntax(
       identifierExpression(lexicalIdentifier("X")),
-      literalRecord("person"),
-      skipStatementSyntax(),
+      [
+        {
+          pattern: literalRecord("person"),
+          statement: skipStatementSyntax(),
+        },
+      ],
       skipStatementSyntax(),
     );
 
@@ -30,6 +36,79 @@ describe("Compiling patternMatching statements", () => {
         identifierExpression(lexicalIdentifier("X")),
         literalRecord("person"),
         skipStatement(),
+        skipStatement(),
+      ),
+    );
+  });
+
+  it("compiles appropriately multiple pattern cases", () => {
+    const statement = patternMatchingStatementSyntax(
+      identifierExpression(lexicalIdentifier("X")),
+      [
+        {
+          pattern: literalRecord("person"),
+          statement: bindingStatementSyntax(
+            lexicalIdentifier("A"),
+            lexicalIdentifier("B"),
+          ),
+        },
+        {
+          pattern: literalRecord("animal"),
+          statement: bindingStatementSyntax(
+            lexicalIdentifier("B"),
+            lexicalIdentifier("C"),
+          ),
+        },
+        {
+          pattern: literalRecord("mineral"),
+          statement: bindingStatementSyntax(
+            lexicalIdentifier("C"),
+            lexicalIdentifier("D"),
+          ),
+        },
+      ],
+      skipStatementSyntax(),
+    );
+
+    expect(compile(statement)).toEqual(
+      patternMatchingStatement(
+        identifierExpression(lexicalIdentifier("X")),
+        literalRecord("person"),
+        bindingStatement(lexicalIdentifier("A"), lexicalIdentifier("B")),
+        patternMatchingStatement(
+          identifierExpression(lexicalIdentifier("X")),
+          literalRecord("animal"),
+          bindingStatement(lexicalIdentifier("B"), lexicalIdentifier("C")),
+          patternMatchingStatement(
+            identifierExpression(lexicalIdentifier("X")),
+            literalRecord("mineral"),
+            bindingStatement(lexicalIdentifier("C"), lexicalIdentifier("D")),
+            skipStatement(),
+          ),
+        ),
+      ),
+    );
+  });
+
+  it("compiles appropriately when not having else clause", () => {
+    const statement = patternMatchingStatementSyntax(
+      identifierExpression(lexicalIdentifier("X")),
+      [
+        {
+          pattern: literalRecord("person"),
+          statement: bindingStatementSyntax(
+            lexicalIdentifier("A"),
+            lexicalIdentifier("B"),
+          ),
+        },
+      ],
+    );
+
+    expect(compile(statement)).toEqual(
+      patternMatchingStatement(
+        identifierExpression(lexicalIdentifier("X")),
+        literalRecord("person"),
+        bindingStatement(lexicalIdentifier("A"), lexicalIdentifier("B")),
         skipStatement(),
       ),
     );


### PR DESCRIPTION
## Summary of changes

Case statements now support both no else clause (which then defaults to `skip`) and multiple pattern clauses.

## Related issues

* Closes kozily/admin#96
