### PR TITLE
146 - Implements expressions on procedure application

### DIFF
--- a/app/oz/built_ins/float.js
+++ b/app/oz/built_ins/float.js
@@ -13,7 +13,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);

--- a/app/oz/built_ins/number.js
+++ b/app/oz/built_ins/number.js
@@ -11,7 +11,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -28,7 +30,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -45,7 +49,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -64,7 +70,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -83,7 +91,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);

--- a/app/oz/built_ins/record.js
+++ b/app/oz/built_ins/record.js
@@ -35,7 +35,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const record = args.getIn([0, "value", "value"]);

--- a/app/oz/built_ins/value.js
+++ b/app/oz/built_ins/value.js
@@ -56,7 +56,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -74,7 +76,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -92,7 +96,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);
@@ -110,7 +116,9 @@ export default {
       const missingArgument = args.find(x => !x.get("value"));
       if (missingArgument) {
         return Immutable.Map({
-          waitCondition: missingArgument.get("variable"),
+          waitCondition:
+            missingArgument.get("waitCondition") ||
+            missingArgument.get("variable"),
         });
       }
       const lhs = args.getIn([0, "value", "value"]);

--- a/app/oz/entailment/index.js
+++ b/app/oz/entailment/index.js
@@ -15,7 +15,10 @@ export const checkers = {
 export const entail = (args, sigma) => {
   const missingArgument = args.find(x => !x.get("value"));
   if (missingArgument) {
-    return Immutable.Map({ waitCondition: missingArgument.get("variable") });
+    return Immutable.Map({
+      waitCondition:
+        missingArgument.get("waitCondition") || missingArgument.get("variable"),
+    });
   }
   if (args.getIn([0, "value", "type"]) !== args.getIn([1, "value", "type"])) {
     return Immutable.Map({ value: false });

--- a/app/oz/execution/by_need.js
+++ b/app/oz/execution/by_need.js
@@ -1,4 +1,5 @@
 import { lookupVariableInSigma } from "../machine/sigma";
+import { identifierExpression } from "../machine/expressions";
 import { lexicalIdentifier } from "../machine/lexical";
 import {
   buildThread,
@@ -26,8 +27,8 @@ export default function(state, semanticStatement) {
 
   if (neededEquivalenceClass.get("value")) {
     const newStatement = procedureApplicationStatement(
-      lexicalIdentifier("TriggerProcedure"),
-      [needed],
+      identifierExpression(lexicalIdentifier("TriggerProcedure")),
+      [identifierExpression(needed)],
     );
     const newThread = buildThread({
       semanticStatements: [

--- a/app/oz/free_identifiers/procedure_application.js
+++ b/app/oz/free_identifiers/procedure_application.js
@@ -1,13 +1,11 @@
 import Immutable from "immutable";
 
 export default (recurse, statement) => {
-  const procedureIdentifier = Immutable.Set([
-    statement.getIn(["procedure", "identifier"]),
-  ]);
+  const procedureIdentifiers = recurse(statement.get("procedure"));
 
-  const argumentIdentifiers = Immutable.Set(
-    statement.get("args").map(x => x.get("identifier")),
-  );
+  const argumentIdentifiers = statement
+    .get("args")
+    .reduce((result, item) => result.union(recurse(item)), Immutable.Set());
 
-  return procedureIdentifier.union(argumentIdentifiers);
+  return procedureIdentifiers.union(argumentIdentifiers);
 };

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -123,10 +123,10 @@ stm_pattern_matching -> "case" __ exp_expression __ "of" __ lit_record_like __ "
   }
 %}
 
-stm_procedure_application -> "{" _ ids_identifier lit_procedure_args:? _ "}" {%
+stm_procedure_application -> "{" _ exp_expression stm_procedure_application_args:? _ "}" {%
   function(d, position, reject) {
     var procedure = d[2];
-    if (STM_SPECIAL_PROCEDURES.indexOf(procedure.identifier) !== -1) {
+    if (procedure.type === "identifier" && STM_SPECIAL_PROCEDURES.indexOf(procedure.identifier.identifier) !== -1) {
       return reject;
     } else {
       return {
@@ -138,6 +138,14 @@ stm_procedure_application -> "{" _ ids_identifier lit_procedure_args:? _ "}" {%
     }
   }
 %}
+
+stm_procedure_application_args ->
+    __ exp_expression {% function(d) { return [d[1]] } %}
+  | stm_procedure_application_args __ exp_expression {%
+    function(d) {
+      return d[0].concat(d[2])
+    }
+  %}
 
 stm_try -> "try" __ stm_sequence __ "catch" __ ids_identifier __ "then" __ stm_sequence __ "end" {%
   function(d) {

--- a/app/oz/machine/sigma.js
+++ b/app/oz/machine/sigma.js
@@ -117,10 +117,60 @@ export const unifyVariableToValue = (sigma, variable, value) => {
     );
 };
 
+export const unifyValues = (sigma, x, y) => {
+  const xAuxiliaryIdentifier = makeAuxiliaryIdentifier();
+  const xAuxiliaryVariable = makeNewVariable({
+    in: sigma,
+    for: xAuxiliaryIdentifier.get("identifier"),
+  });
+  const xAuxiliaryEquivalenceClass = buildEquivalenceClass(
+    x,
+    xAuxiliaryVariable,
+  );
+
+  const yAuxiliaryIdentifier = makeAuxiliaryIdentifier();
+  const yAuxiliaryVariable = makeNewVariable({
+    in: sigma,
+    for: yAuxiliaryIdentifier.get("identifier"),
+  });
+  const yAuxiliaryEquivalenceClass = buildEquivalenceClass(
+    y,
+    yAuxiliaryVariable,
+  );
+
+  const intermediateSigma = sigma
+    .add(xAuxiliaryEquivalenceClass)
+    .add(yAuxiliaryEquivalenceClass);
+
+  const unifiedSigma = unify(
+    intermediateSigma,
+    xAuxiliaryVariable,
+    yAuxiliaryVariable,
+  );
+
+  return unifiedSigma;
+};
+
 export const unifyVariableToEvaluation = (sigma, variable, evaluation) => {
   if (evaluation.get("variable")) {
     return unify(sigma, variable, evaluation.get("variable"));
   }
 
   return unifyVariableToValue(sigma, variable, evaluation.get("value"));
+};
+
+export const unifyEvaluations = (sigma, x, y) => {
+  if (x.get("variable") && y.get("variable")) {
+    return unify(sigma, x.get("variable"), y.get("variable"));
+  }
+
+  if (x.get("variable")) {
+    return unifyVariableToValue(sigma, x.get("variable"), y.get("value"));
+  }
+
+  if (y.get("variable")) {
+    return unifyVariableToValue(sigma, y.get("variable"), x.get("value"));
+  }
+
+  return unifyValues(sigma, x.get("value"), y.get("value"));
 };

--- a/app/oz/machine/threads.js
+++ b/app/oz/machine/threads.js
@@ -7,6 +7,7 @@ import {
 } from "./build";
 import { lookupVariableInSigma } from "./sigma";
 import { procedureApplicationStatement } from "./statements";
+import { identifierExpression } from "./expressions";
 import { lexicalIdentifier } from "./lexical";
 
 export const blockCurrentThread = (
@@ -53,8 +54,8 @@ export const activateTrigger = (state, trigger) => {
   const procedureIdentifier = trigger.get("procedureIdentifier");
   const neededVariableIdentifier = trigger.get("neededVariableIdentifier");
   const statement = procedureApplicationStatement(
-    lexicalIdentifier(procedureIdentifier),
-    [lexicalIdentifier(neededVariableIdentifier)],
+    identifierExpression(lexicalIdentifier(procedureIdentifier)),
+    [identifierExpression(lexicalIdentifier(neededVariableIdentifier))],
   );
   const environment = buildEnvironment({
     [procedureIdentifier]: trigger.get("procedure"),

--- a/app/oz/print/procedure_application.js
+++ b/app/oz/print/procedure_application.js
@@ -1,9 +1,9 @@
 export default (recurse, node, identation) => {
   const ident = new Array(identation + 1).join(" ");
-  const procedureIdentifier = node.getIn(["procedure", "identifier"]);
+  const procedureIdentifier = recurse(node.get("procedure")).abbreviated;
   const args = node
     .get("args")
-    .map(x => x.get("identifier"))
+    .map(x => recurse(x).abbreviated)
     .join(" ");
   const result = `${ident}{${procedureIdentifier} ${args}}`;
   return {

--- a/app/state/parse.js
+++ b/app/state/parse.js
@@ -2,6 +2,9 @@ import Immutable from "immutable";
 import parser from "../oz/parser";
 import { compile } from "../oz/compilation";
 import { collectFreeIdentifiers } from "../oz/free_identifiers";
+import { defaultEnvironment } from "../oz/machine/build";
+
+const defaultIdentifiers = Immutable.Set(defaultEnvironment().keySeq());
 
 export const initialState = Immutable.fromJS({
   error: undefined,
@@ -22,7 +25,9 @@ export const reducer = (previousState = initialState, action) => {
       try {
         const ast = parser(action.payload);
         const compilation = compile(ast);
-        const freeIdentifiers = collectFreeIdentifiers(compilation);
+        const freeIdentifiers = collectFreeIdentifiers(compilation).subtract(
+          defaultIdentifiers,
+        );
         if (!freeIdentifiers.isEmpty()) {
           throw new Error(
             `Undeclared identifiers ${freeIdentifiers.join(", ")}`,

--- a/specs/built_ins/float_div_spec.js
+++ b/specs/built_ins/float_div_spec.js
@@ -95,6 +95,26 @@ describe("The float division built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns the appropriate value when both arguments are valid", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(14) },

--- a/specs/built_ins/number_addition_spec.js
+++ b/specs/built_ins/number_addition_spec.js
@@ -87,6 +87,26 @@ describe("The number addition built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns the appropriate value when both arguments are valid", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(2) },

--- a/specs/built_ins/number_division_spec.js
+++ b/specs/built_ins/number_division_spec.js
@@ -95,6 +95,26 @@ describe("The number division built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns the appropriate value when both arguments are valid", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(13) },

--- a/specs/built_ins/number_modulo_spec.js
+++ b/specs/built_ins/number_modulo_spec.js
@@ -87,6 +87,26 @@ describe("The number modulo built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns the appropriate value when both arguments are valid", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(14) },

--- a/specs/built_ins/number_multplication_spec.js
+++ b/specs/built_ins/number_multplication_spec.js
@@ -87,6 +87,26 @@ describe("The number multiplication built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns the appropriate value when both arguments are valid", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(14) },

--- a/specs/built_ins/number_subtraction_spec.js
+++ b/specs/built_ins/number_subtraction_spec.js
@@ -87,6 +87,26 @@ describe("The number subtraction built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns the appropriate value when both arguments are valid", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(14) },

--- a/specs/built_ins/record_selection_spec.js
+++ b/specs/built_ins/record_selection_spec.js
@@ -113,6 +113,26 @@ describe("The record selection built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns an undefined value but proper variable when the variable is unbound", () => {
       const args = Immutable.fromJS([
         { value: valueRecord("person", { name: buildVariable("n", 0) }) },

--- a/specs/built_ins/value_entailment_spec.js
+++ b/specs/built_ins/value_entailment_spec.js
@@ -116,5 +116,21 @@ describe("The entailment/disentailment check built-ins", () => {
       ]);
       expectUndefinedEvaluationResult(args, buildVariable("x", 0));
     });
+
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueAtom("person") },
+      ]);
+      expectUndefinedEvaluationResult(args, buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueAtom("person") },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      expectUndefinedEvaluationResult(args, buildVariable("x", 0));
+    });
   });
 });

--- a/specs/built_ins/value_greater_than_equal_spec.js
+++ b/specs/built_ins/value_greater_than_equal_spec.js
@@ -10,7 +10,7 @@ import { buildVariable } from "../../app/oz/machine/build";
 
 const operator = builtIns["Value"][">="];
 
-describe("The value less than built-in", () => {
+describe("The value greater than or equal built-in", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
@@ -94,6 +94,26 @@ describe("The value less than built-in", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(3) },
         { value: undefined, variable: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
       ]);
       const evaluation = operator.evaluate(args);
       expect(evaluation.get("value")).toEqual(undefined);

--- a/specs/built_ins/value_greater_than_spec.js
+++ b/specs/built_ins/value_greater_than_spec.js
@@ -10,7 +10,7 @@ import { buildVariable } from "../../app/oz/machine/build";
 
 const operator = builtIns["Value"][">"];
 
-describe("The value less than built-in", () => {
+describe("The value greater than built-in", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
@@ -94,6 +94,26 @@ describe("The value less than built-in", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(3) },
         { value: undefined, variable: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
       ]);
       const evaluation = operator.evaluate(args);
       expect(evaluation.get("value")).toEqual(undefined);

--- a/specs/built_ins/value_less_than_equal_spec.js
+++ b/specs/built_ins/value_less_than_equal_spec.js
@@ -10,7 +10,7 @@ import { buildVariable } from "../../app/oz/machine/build";
 
 const operator = builtIns["Value"]["<="];
 
-describe("The value less than built-in", () => {
+describe("The value less than or equal built-in", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
@@ -94,6 +94,26 @@ describe("The value less than built-in", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(3) },
         { value: undefined, variable: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
       ]);
       const evaluation = operator.evaluate(args);
       expect(evaluation.get("value")).toEqual(undefined);

--- a/specs/built_ins/value_less_than_spec.js
+++ b/specs/built_ins/value_less_than_spec.js
@@ -100,6 +100,26 @@ describe("The value less than built-in", () => {
       expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
     });
 
+    it("cascades wait conditions when the first argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+        { value: valueNumber(3) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
+    it("cascades wait conditions when the second argument is a wait condition", () => {
+      const args = Immutable.fromJS([
+        { value: valueNumber(3) },
+        { value: undefined, waitCondition: buildVariable("x", 0) },
+      ]);
+      const evaluation = operator.evaluate(args);
+      expect(evaluation.get("value")).toEqual(undefined);
+      expect(evaluation.get("waitCondition")).toEqual(buildVariable("x", 0));
+    });
+
     it("returns true when the first argument is a number less than the second argument", () => {
       const args = Immutable.fromJS([
         { value: valueNumber(2) },

--- a/specs/compilation/procedure_application_spec.js
+++ b/specs/compilation/procedure_application_spec.js
@@ -2,6 +2,7 @@ import Immutable from "immutable";
 import { compile } from "../../app/oz/compilation";
 import { procedureApplicationStatementSyntax } from "../../app/oz/machine/statementSyntax";
 import { procedureApplicationStatement } from "../../app/oz/machine/statements";
+import { identifierExpression } from "../../app/oz/machine/expressions";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
 describe("Compiling procedure application statements", () => {
@@ -11,15 +12,21 @@ describe("Compiling procedure application statements", () => {
 
   it("compiles appropriately", () => {
     const statement = procedureApplicationStatementSyntax(
-      lexicalIdentifier("Sum"),
-      [lexicalIdentifier("A"), lexicalIdentifier("B")],
+      identifierExpression(lexicalIdentifier("Sum")),
+      [
+        identifierExpression(lexicalIdentifier("A")),
+        identifierExpression(lexicalIdentifier("B")),
+      ],
     );
 
     expect(compile(statement)).toEqual(
-      procedureApplicationStatement(lexicalIdentifier("Sum"), [
-        lexicalIdentifier("A"),
-        lexicalIdentifier("B"),
-      ]),
+      procedureApplicationStatement(
+        identifierExpression(lexicalIdentifier("Sum")),
+        [
+          identifierExpression(lexicalIdentifier("A")),
+          identifierExpression(lexicalIdentifier("B")),
+        ],
+      ),
     );
   });
 });

--- a/specs/execution/by_need_spec.js
+++ b/specs/execution/by_need_spec.js
@@ -4,6 +4,7 @@ import {
   byNeedStatement,
   procedureApplicationStatement,
 } from "../../app/oz/machine/statements";
+import { identifierExpression } from "../../app/oz/machine/expressions";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 import { valueNumber } from "../../app/oz/machine/values";
 import {
@@ -86,8 +87,8 @@ describe("Reducing by need statements", () => {
             semanticStatements: [
               buildSemanticStatement(
                 procedureApplicationStatement(
-                  lexicalIdentifier("TriggerProcedure"),
-                  [lexicalIdentifier("W")],
+                  identifierExpression(lexicalIdentifier("TriggerProcedure")),
+                  [identifierExpression(lexicalIdentifier("W"))],
                 ),
                 buildEnvironment({
                   TriggerProcedure: buildVariable("x", 0),

--- a/specs/free_identifiers/procedure_application_spec.js
+++ b/specs/free_identifiers/procedure_application_spec.js
@@ -1,6 +1,7 @@
 import Immutable from "immutable";
 import { collectFreeIdentifiers } from "../../app/oz/free_identifiers";
 import { procedureApplicationStatement } from "../../app/oz/machine/statements";
+import { identifierExpression } from "../../app/oz/machine/expressions";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
 describe("Collecting free identifiers in a procedure application statement", () => {
@@ -9,10 +10,13 @@ describe("Collecting free identifiers in a procedure application statement", () 
   });
 
   it("collects the procedure identifier and any arguments", () => {
-    const statement = procedureApplicationStatement(lexicalIdentifier("P"), [
-      lexicalIdentifier("X"),
-      lexicalIdentifier("Y"),
-    ]);
+    const statement = procedureApplicationStatement(
+      identifierExpression(lexicalIdentifier("P")),
+      [
+        identifierExpression(lexicalIdentifier("X")),
+        identifierExpression(lexicalIdentifier("Y")),
+      ],
+    );
     expect(collectFreeIdentifiers(statement)).toEqual(
       Immutable.Set(["P", "X", "Y"]),
     );

--- a/specs/machine/threads/process_triggers_spec.js
+++ b/specs/machine/threads/process_triggers_spec.js
@@ -5,6 +5,7 @@ import {
   procedureApplicationStatement,
 } from "../../../app/oz/machine/statements";
 import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import { identifierExpression } from "../../../app/oz/machine/expressions";
 import { literalNumber } from "../../../app/oz/machine/literals";
 import { valueProcedure, valueNumber } from "../../../app/oz/machine/values";
 import {
@@ -95,8 +96,8 @@ describe("threads#processTriggers", () => {
             semanticStatements: [
               buildSemanticStatement(
                 procedureApplicationStatement(
-                  lexicalIdentifier("TriggerProcedure"),
-                  [lexicalIdentifier("X")],
+                  identifierExpression(lexicalIdentifier("TriggerProcedure")),
+                  [identifierExpression(lexicalIdentifier("X"))],
                 ),
                 buildEnvironment({
                   TriggerProcedure: buildVariable("p", 0),
@@ -152,8 +153,8 @@ describe("threads#processTriggers", () => {
             semanticStatements: [
               buildSemanticStatement(
                 procedureApplicationStatement(
-                  lexicalIdentifier("TriggerProcedure"),
-                  [lexicalIdentifier("X")],
+                  identifierExpression(lexicalIdentifier("TriggerProcedure")),
+                  [identifierExpression(lexicalIdentifier("X"))],
                 ),
                 buildEnvironment({
                   TriggerProcedure: buildVariable("p", 0),

--- a/specs/parser/statements/procedure_application_spec.js
+++ b/specs/parser/statements/procedure_application_spec.js
@@ -1,4 +1,5 @@
 import Immutable from "immutable";
+import { identifierExpression } from "../../../app/oz/machine/expressions";
 import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
 import { procedureApplicationStatementSyntax } from "../../../app/oz/machine/statementSyntax";
 import parse from "../../../app/oz/parser";
@@ -11,13 +12,17 @@ describe("Parsing {X ...} statements", () => {
   describe("when no arguments are provided", () => {
     it("handles condensed syntax correctly", () => {
       expect(parse("{SomeProcedure}")).toEqual(
-        procedureApplicationStatementSyntax(lexicalIdentifier("SomeProcedure")),
+        procedureApplicationStatementSyntax(
+          identifierExpression(lexicalIdentifier("SomeProcedure")),
+        ),
       );
     });
 
     it("handles whitespaced syntax correctly", () => {
       expect(parse("{\n   SomeProcedure\t\t  \n}")).toEqual(
-        procedureApplicationStatementSyntax(lexicalIdentifier("SomeProcedure")),
+        procedureApplicationStatementSyntax(
+          identifierExpression(lexicalIdentifier("SomeProcedure")),
+        ),
       );
     });
   });
@@ -26,10 +31,10 @@ describe("Parsing {X ...} statements", () => {
     it("handles condensed syntax correctly", () => {
       expect(parse("{SomeProcedure FirstArgument SecondArgument}")).toEqual(
         procedureApplicationStatementSyntax(
-          lexicalIdentifier("SomeProcedure"),
+          identifierExpression(lexicalIdentifier("SomeProcedure")),
           [
-            lexicalIdentifier("FirstArgument"),
-            lexicalIdentifier("SecondArgument"),
+            identifierExpression(lexicalIdentifier("FirstArgument")),
+            identifierExpression(lexicalIdentifier("SecondArgument")),
           ],
         ),
       );
@@ -42,10 +47,10 @@ describe("Parsing {X ...} statements", () => {
         ),
       ).toEqual(
         procedureApplicationStatementSyntax(
-          lexicalIdentifier("SomeProcedure"),
+          identifierExpression(lexicalIdentifier("SomeProcedure")),
           [
-            lexicalIdentifier("FirstArgument"),
-            lexicalIdentifier("SecondArgument"),
+            identifierExpression(lexicalIdentifier("FirstArgument")),
+            identifierExpression(lexicalIdentifier("SecondArgument")),
           ],
         ),
       );

--- a/specs/print/procedure_application_spec.js
+++ b/specs/print/procedure_application_spec.js
@@ -1,6 +1,7 @@
 import Immutable from "immutable";
 import { print } from "../../app/oz/print";
 import { procedureApplicationStatement } from "../../app/oz/machine/statements";
+import { identifierExpression } from "../../app/oz/machine/expressions";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
 describe("Printing a procedure application statement", () => {
@@ -9,11 +10,14 @@ describe("Printing a procedure application statement", () => {
   });
 
   it("Returns the appropriate string", () => {
-    const statement = procedureApplicationStatement(lexicalIdentifier("Sum"), [
-      lexicalIdentifier("A"),
-      lexicalIdentifier("B"),
-      lexicalIdentifier("C"),
-    ]);
+    const statement = procedureApplicationStatement(
+      identifierExpression(lexicalIdentifier("Sum")),
+      [
+        identifierExpression(lexicalIdentifier("A")),
+        identifierExpression(lexicalIdentifier("B")),
+        identifierExpression(lexicalIdentifier("C")),
+      ],
+    );
     const result = print(statement, 2);
 
     expect(result.abbreviated).toEqual("  {Sum A B C}");


### PR DESCRIPTION
## Summary of changes

* Implement expression evaluation on procedure application, both for the procedure identifier as well as the arguments, and both in the case of built-in procedures and user-defined procedures.

* Fixes a bug where certain built-in operations didn't cascade wait conditions when a subexpression raised a wait condition.

## Related issues

* Closes kozily/admin#146
