### PR TITLE
128 - List literals

### DIFF
--- a/app/oz/built_ins/record.js
+++ b/app/oz/built_ins/record.js
@@ -42,9 +42,12 @@ export default {
       }
       const record = args.getIn([0, "value", "value"]);
       const feature = args.getIn([1, "value", "value", "label"]);
-      const variable = record.getIn(["features", feature]);
-      const value = lookupVariableInSigma(sigma, variable).get("value");
-      return Immutable.fromJS({ value, variable });
+      const featureContents = record.getIn(["features", feature]);
+      if (featureContents.get("node") === "value") {
+        return Immutable.fromJS({ value: featureContents });
+      }
+      const value = lookupVariableInSigma(sigma, featureContents).get("value");
+      return Immutable.fromJS({ value, variable: featureContents });
     },
   },
 };

--- a/app/oz/compilation/record.js
+++ b/app/oz/compilation/record.js
@@ -1,3 +1,11 @@
 export default (recurse, node) => {
-  return node;
+  return node.updateIn(["value", "features"], features => {
+    return features.map(feature => {
+      if (feature.get("node") !== "identifier") {
+        return recurse(feature);
+      }
+
+      return feature;
+    });
+  });
 };

--- a/app/oz/execution/by_need.js
+++ b/app/oz/execution/by_need.js
@@ -1,4 +1,4 @@
-import { lookupVariableInSigma, evaluationToVariable } from "../machine/sigma";
+import { lookupVariableInSigma, convertToVariable } from "../machine/sigma";
 import { identifierExpression } from "../machine/expressions";
 import { lexicalIdentifier } from "../machine/lexical";
 import {
@@ -32,7 +32,7 @@ export default function(state, semanticStatement, activeThreadIndex) {
   const {
     sigma: augmentedSigma,
     variable: procedureVariable,
-  } = evaluationToVariable(evaluation, sigma, "triggerProcedure");
+  } = convertToVariable(evaluation, sigma, "triggerProcedure");
 
   const needed = statement.get("neededIdentifier");
   const neededIdentifier = needed.get("identifier");

--- a/app/oz/execution/exception_raise.js
+++ b/app/oz/execution/exception_raise.js
@@ -1,6 +1,6 @@
 import { buildSemanticStatement } from "../machine/build";
 import { UncaughtOzExceptionError } from "../machine/exceptions";
-import { evaluationToVariable } from "../machine/sigma";
+import { convertToVariable } from "../machine/sigma";
 import { blockCurrentThread } from "../machine/threads";
 import { evaluate } from "../expression";
 import { makeNewEnvironmentIndex } from "../machine/environment";
@@ -29,7 +29,7 @@ export default function(state, semanticStatement, activeThreadIndex) {
   const {
     sigma: augmentedSigma,
     variable: exceptionVariable,
-  } = evaluationToVariable(exceptionEvaluation, sigma, "exception");
+  } = convertToVariable(exceptionEvaluation, sigma, "exception");
 
   if (exceptionEvaluation.get("waitCondition")) {
     return blockCurrentThread(

--- a/app/oz/execution/procedure_application.js
+++ b/app/oz/execution/procedure_application.js
@@ -1,5 +1,5 @@
 import Immutable from "immutable";
-import { unifyEvaluations, evaluationToVariable } from "../machine/sigma";
+import { unify, convertToVariable } from "../machine/sigma";
 import { buildSemanticStatement } from "../machine/build";
 import {
   failureException,
@@ -59,7 +59,7 @@ const executeBuiltInValue = (
       );
     }
     return state.update("sigma", sigma =>
-      unifyEvaluations(sigma, resultEvaluation, builtInEvaluation),
+      unify(sigma, resultEvaluation, builtInEvaluation),
     );
   } catch (error) {
     return raiseSystemException(state, activeThreadIndex, failureException());
@@ -102,7 +102,7 @@ const executeProcedureValue = (
       const {
         sigma: newAugmentedSigma,
         variable: callArgumentVariable,
-      } = evaluationToVariable(evaluation, augmentedSigma, "argument");
+      } = convertToVariable(evaluation, augmentedSigma, "argument");
       return {
         augmentedSigma: newAugmentedSigma,
         callArgumentVariables: callArgumentVariables.push(callArgumentVariable),

--- a/app/oz/execution/value_creation.js
+++ b/app/oz/execution/value_creation.js
@@ -1,4 +1,4 @@
-import { unifyVariableToEvaluation } from "../machine/sigma";
+import { unify } from "../machine/sigma";
 import {
   errorException,
   failureException,
@@ -29,9 +29,7 @@ export default function(state, semanticStatement, activeThreadIndex) {
     }
 
     try {
-      return state.update("sigma", sigma =>
-        unifyVariableToEvaluation(sigma, variable, evaluation),
-      );
+      return state.update("sigma", sigma => unify(sigma, variable, evaluation));
     } catch (error) {
       return raiseSystemException(state, activeThreadIndex, failureException());
     }

--- a/app/oz/free_identifiers/record.js
+++ b/app/oz/free_identifiers/record.js
@@ -1,8 +1,16 @@
 import Immutable from "immutable";
 
 export default (recurse, literal) => {
-  const features = literal.getIn(["value", "features"]);
-  const identifiers = features.valueSeq().map(id => id.get("identifier"));
+  const identifiers = literal
+    .getIn(["value", "features"])
+    .valueSeq()
+    .flatMap(feature => {
+      if (feature.get("node") === "identifier") {
+        return Immutable.Set(feature.get("identifier"));
+      }
+
+      return recurse(feature);
+    });
 
   return Immutable.Set(identifiers);
 };

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -359,9 +359,15 @@ lit_record_feature_list ->
     lit_record_feature_list __ lit_record_feature {% function(d) { return d[0].concat(d[2]); } %}
   | lit_record_feature
 
-lit_record_feature -> lit_atom_syntax ":" ids_identifier {%
+lit_record_feature -> lit_atom_syntax ":" lit_record_value {%
   function(d, position, reject) {
     return {name: d[0], value: d[2]};
+  }
+%}
+
+lit_record_value -> (ids_identifier|lit_value) {%
+  function(d) {
+    return d[0][0];
   }
 %}
 
@@ -490,12 +496,18 @@ lit_empty_list -> "[" _ "]" {%
 %}
 
 lit_list_items ->
-    ids_identifier
-  | lit_list_items __ ids_identifier {%
+    lit_list_item
+  | lit_list_items __ lit_list_item {%
       function(d) {
         return d[0].concat(d[2]);
       }
     %}
+
+lit_list_item -> (ids_identifier | lit_value) {%
+  function(d) {
+    return d[0][0];
+  }
+%}
 
 ##############################################################################
 # Strings

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -445,18 +445,66 @@ lit_record_like ->
   | lit_boolean {% id %}
 
 ##############################################################################
+# Tuple
+##############################################################################
+
+lit_tuple -> lit_atom_syntax "(" _ lit_list_items _ ")" {%
+  function(d, position, reject) {
+    var label = d[0];
+    var features = d[3].reduce(function(result, item, index) {
+      result[++index] = item;
+      return result;
+    }, {});
+    return litBuildRecord(label, features);
+  }
+%}
+
+##############################################################################
+# List
+##############################################################################
+@{%
+  function litBuildList(items) {
+    return items.reduceRight(function(result, item) {
+      return litBuildRecord("|", {
+        1: item,
+        2: result,
+      });
+    }, litBuildRecord("nil", {}));
+  }
+%}
+
+lit_list ->
+    lit_empty_list {% id %}
+  | lit_list_with_items {% id %}
+
+lit_list_with_items -> "[" _ lit_list_items _ "]" {%
+  function(d) {
+    return litBuildList(d[2]);
+  }
+%}
+
+lit_empty_list -> "[" _ "]" {%
+  function(d) {
+    return litBuildList([]);
+  }
+%}
+
+lit_list_items ->
+    ids_identifier
+  | lit_list_items __ ids_identifier {%
+      function(d) {
+        return d[0].concat(d[2]);
+      }
+    %}
+
+##############################################################################
 # Strings
 ##############################################################################
 @{%
   function litBuildString(d) {
-    if (d[0] === "") {
-      return litBuildRecord("nil", {});
-    } else {
-      return litBuildRecord("|", {
-        1: d[0].charCodeAt(0),
-        2: litBuildString([d[0].substring(1)]),
-      });
-    }
+    return litBuildList(d[0].split("").map(function(s) {
+      return litBuildNumber([s.charCodeAt(0)])
+    }));
   }
 %}
 
@@ -573,56 +621,6 @@ lit_float -> "~":? [0-9]:+ "." [0-9]:* (("e" | "E") "~":? [0-9]:+):? {%
       d[3].join("") +
       (d[4] ? "e" + (translateWeirdOzUnaryMinus(d[4][1]) + d[4][2].join("")) : "")
     )]);
-  }
-%}
-
-##############################################################################
-# List
-##############################################################################
-
-lit_list ->
-    lit_empty_list {% id %}
-  | lit_list_with_items {% id %}
-
-lit_list_with_items -> "[" _ lit_list_items _ "]" {%
-  function(d) {
-    return d[2].reduceRight(
-      function(a, b) {
-        return litBuildRecord("|", {1: b, 2:a});
-      },
-      litBuildRecord("nil", {})
-    );
-  }
-%}
-
-lit_empty_list -> "[" _ "]" {%
-  function(d) {
-    return litBuildRecord("nil", {});
-  }
-%}
-
-lit_list_items ->
-    ids_identifier
-  | lit_list_items __ ids_identifier {%
-      function(d) {
-        return d[0].concat(d[2]);
-      }
-    %}
-
-
-
-##############################################################################
-# Tuple
-##############################################################################
-
-lit_tuple -> lit_atom_syntax "(" _ lit_list_items _ ")" {%
-  function(d, position, reject) {
-    var label = d[0];
-    var features = d[3].reduce(function(result, item, index) {
-      result[++index] = item;
-      return result;
-    }, {});
-    return litBuildRecord(label, features);
   }
 %}
 

--- a/app/oz/machine/literals.js
+++ b/app/oz/machine/literals.js
@@ -8,6 +8,25 @@ export const literalTypes = {
 
 export const allLiteralTypes = Object.keys(literalTypes);
 
+export const literalNumber = value => {
+  return Immutable.fromJS({
+    node: "literal",
+    type: "number",
+    value,
+  });
+};
+
+export const literalProcedure = (args = [], body) => {
+  return Immutable.fromJS({
+    node: "literal",
+    type: "procedure",
+    value: {
+      args,
+      body,
+    },
+  });
+};
+
 export const literalRecord = (label, features = {}) => {
   return Immutable.fromJS({
     node: "literal",
@@ -44,36 +63,11 @@ export const literalListItem = (head, tail) => {
 export const literalList = (items = []) => {
   return items.reduceRight(
     (result, item) => literalListItem(item, result),
-    literalRecord("nil"),
+    literalAtom("nil"),
   );
 };
 
 export const literalString = value => {
-  if (value === "") {
-    return literalList();
-  }
-
-  return literalListItem(
-    value.charCodeAt(0),
-    literalString(value.substring(1)),
-  );
-};
-
-export const literalNumber = value => {
-  return Immutable.fromJS({
-    node: "literal",
-    type: "number",
-    value,
-  });
-};
-
-export const literalProcedure = (args = [], body) => {
-  return Immutable.fromJS({
-    node: "literal",
-    type: "procedure",
-    value: {
-      args,
-      body,
-    },
-  });
+  const items = value.split("").map(s => literalNumber(s.charCodeAt(0)));
+  return literalList(items);
 };

--- a/app/oz/machine/values.js
+++ b/app/oz/machine/values.js
@@ -1,5 +1,34 @@
 import Immutable from "immutable";
 
+export const valueNumber = value => {
+  return Immutable.fromJS({
+    node: "value",
+    type: "number",
+    value,
+  });
+};
+
+export const valueProcedure = (args = [], body, context = {}) => {
+  return Immutable.fromJS({
+    node: "value",
+    type: "procedure",
+    value: {
+      args,
+      body,
+      context,
+    },
+  });
+};
+
+export const valueBuiltIn = (operator, namespace) => {
+  return Immutable.fromJS({
+    node: "value",
+    type: "builtIn",
+    operator,
+    namespace,
+  });
+};
+
 export const valueTypes = {
   number: "number",
   record: "record",
@@ -45,43 +74,11 @@ export const valueListItem = (head, tail) => {
 export const valueList = (items = []) => {
   return items.reduceRight(
     (result, item) => valueListItem(item, result),
-    valueRecord("nil"),
+    valueAtom("nil"),
   );
 };
 
 export const valueString = value => {
-  if (value === "") {
-    return valueList();
-  }
-
-  return valueListItem(value.charCodeAt(0), valueString(value.substring(1)));
-};
-
-export const valueNumber = value => {
-  return Immutable.fromJS({
-    node: "value",
-    type: "number",
-    value,
-  });
-};
-
-export const valueProcedure = (args = [], body, context = {}) => {
-  return Immutable.fromJS({
-    node: "value",
-    type: "procedure",
-    value: {
-      args,
-      body,
-      context,
-    },
-  });
-};
-
-export const valueBuiltIn = (operator, namespace) => {
-  return Immutable.fromJS({
-    node: "value",
-    type: "builtIn",
-    operator,
-    namespace,
-  });
+  const items = value.split("").map(s => valueNumber(s.charCodeAt(0)));
+  return valueList(items);
 };

--- a/app/oz/print/literals/record.js
+++ b/app/oz/print/literals/record.js
@@ -7,12 +7,16 @@ const printLabel = label => {
   return `'${label}'`;
 };
 
-const printValuePosition = node => {
-  if (node.get("node") === "identifier") {
-    return node.get("identifier");
+const printValue = (recurse, node) => {
+  if (node.get("node") === "literal") {
+    return recurse(node);
   }
 
-  return `${node.get("name")}${node.get("sequence")}`;
+  const printed = node.get("identifier");
+  return {
+    abbreviated: printed,
+    full: printed,
+  };
 };
 
 const isInteger = value => {
@@ -20,45 +24,84 @@ const isInteger = value => {
   return integerRegex.test(value);
 };
 
-const printTupleRecord = (label, features) => {
-  const printedFeatures = features
-    .entrySeq()
-    .sortBy(entry => parseInt(entry[0]))
-    .map(entry => `${printValuePosition(entry[1])}`)
-    .join(" ");
-
-  return `${printLabel(label)}(${printedFeatures})`;
-};
-
-const printGenericRecord = (label, features) => {
+const printGenericRecord = (recurse, label, features) => {
   const printedFeatures = features
     .entrySeq()
     .sortBy(entry => entry[0])
-    .map(entry => `${entry[0]}:${printValuePosition(entry[1])}`)
+    .map(entry => ({
+      feature: entry[0],
+      value: printValue(recurse, entry[1]),
+    }));
+
+  const abbreviatedFeatures = printedFeatures.map(
+    entry => `${entry.feature}:${entry.value.abbreviated}`,
+  );
+  const fullFeatures = printedFeatures.map(
+    entry => `${entry.feature}:${entry.value.full}`,
+  );
+
+  return {
+    abbreviated: `${printLabel(label)}(${abbreviatedFeatures.join(" ")})`,
+    full: `${printLabel(label)}(${fullFeatures.join(" ")})`,
+  };
+};
+
+const collectListRecordItems = (recurse, label, features) => {
+  if (label === "nil") {
+    return [""];
+  }
+
+  const firstItem = printValue(recurse, features.get("1")).abbreviated;
+  const tail = features.get("2");
+  const tailLabel = tail.getIn(["value", "label"]);
+  const tailFeatures = tail.getIn(["value", "features"]);
+
+  return [firstItem].concat(
+    collectListRecordItems(recurse, tailLabel, tailFeatures),
+  );
+};
+
+const printListRecord = (recurse, label, features) => {
+  const items = collectListRecordItems(recurse, label, features).filter(
+    x => !!x,
+  );
+  return `[${items.join(" ")}]`;
+};
+
+const printTupleRecord = (recurse, label, features) => {
+  const printedFeatures = features
+    .entrySeq()
+    .sortBy(entry => parseInt(entry[0]))
+    .map(entry => `${printValue(recurse, entry[1]).abbreviated}`)
     .join(" ");
 
   return `${printLabel(label)}(${printedFeatures})`;
-};
-
-const printSpecificRecord = (label, features) => {
-  if (features.isEmpty()) {
-    return printLabel(label);
-  }
-
-  if (features.keySeq().every(key => isInteger(key))) {
-    return printTupleRecord(label, features);
-  }
-
-  return printGenericRecord(label, features);
 };
 
 export default (recurse, node) => {
   const value = node.get("value");
   const label = value.get("label");
   const features = value.get("features");
-  const result = `${printSpecificRecord(label, features)}`;
-  return {
-    abbreviated: result,
-    full: result,
-  };
+  if (features.isEmpty()) {
+    const printedLabel = printLabel(label);
+    return { abbreviated: printedLabel, full: printedLabel };
+  }
+
+  if (label === "|") {
+    const printed = printListRecord(recurse, label, features);
+    return {
+      abbreviated: printed,
+      full: printed,
+    };
+  }
+
+  if (features.keySeq().every(key => isInteger(key))) {
+    const printed = printTupleRecord(recurse, label, features);
+    return {
+      abbreviated: printed,
+      full: printed,
+    };
+  }
+
+  return printGenericRecord(recurse, label, features);
 };

--- a/app/oz/print/literals/record.js
+++ b/app/oz/print/literals/record.js
@@ -20,24 +20,6 @@ const isInteger = value => {
   return integerRegex.test(value);
 };
 
-const collectListRecordItems = (label, features) => {
-  if (label === "nil") {
-    return [""];
-  }
-
-  const firstItem = printValuePosition(features.get("1"));
-  const tail = features.get("2");
-  const tailLabel = tail.getIn(["value", "label"]);
-  const tailFeatures = tail.getIn(["value", "features"]);
-
-  return [firstItem].concat(collectListRecordItems(tailLabel, tailFeatures));
-};
-
-const printListRecord = (label, features) => {
-  const items = collectListRecordItems(label, features).filter(x => !!x);
-  return `[${items.join(" ")}]`;
-};
-
 const printTupleRecord = (label, features) => {
   const printedFeatures = features
     .entrySeq()
@@ -61,10 +43,6 @@ const printGenericRecord = (label, features) => {
 const printSpecificRecord = (label, features) => {
   if (features.isEmpty()) {
     return printLabel(label);
-  }
-
-  if (label === "|") {
-    return printListRecord(label, features);
   }
 
   if (features.keySeq().every(key => isInteger(key))) {

--- a/app/oz/print/values/record.js
+++ b/app/oz/print/values/record.js
@@ -7,12 +7,16 @@ const printLabel = label => {
   return `'${label}'`;
 };
 
-const printValuePosition = node => {
-  if (node.get("node") === "identifier") {
-    return node.get("identifier");
+const printValue = (recurse, node) => {
+  if (node.get("node") === "value") {
+    return recurse(node);
   }
 
-  return `${node.get("name")}${node.get("sequence")}`;
+  const printed = `${node.get("name")}${node.get("sequence")}`;
+  return {
+    abbreviated: printed,
+    full: printed,
+  };
 };
 
 const isInteger = value => {
@@ -20,67 +24,82 @@ const isInteger = value => {
   return integerRegex.test(value);
 };
 
-const collectListRecordItems = (label, features) => {
+const printGenericRecord = (recurse, label, features) => {
+  const printedFeatures = features
+    .entrySeq()
+    .sortBy(entry => entry[0])
+    .map(entry => ({
+      feature: entry[0],
+      value: printValue(recurse, entry[1]),
+    }));
+
+  const abbreviatedFeatures = printedFeatures.map(
+    entry => `${entry.feature}:${entry.value.abbreviated}`,
+  );
+  const fullFeatures = printedFeatures.map(
+    entry => `${entry.feature}:${entry.value.full}`,
+  );
+
+  return {
+    abbreviated: `${printLabel(label)}(${abbreviatedFeatures.join(" ")})`,
+    full: `${printLabel(label)}(${fullFeatures.join(" ")})`,
+  };
+};
+
+const collectListRecordItems = (recurse, label, features) => {
   if (label === "nil") {
     return [""];
   }
 
-  const firstItem = printValuePosition(features.get("1"));
+  const firstItem = printValue(recurse, features.get("1")).abbreviated;
   const tail = features.get("2");
   const tailLabel = tail.getIn(["value", "label"]);
   const tailFeatures = tail.getIn(["value", "features"]);
 
-  return [firstItem].concat(collectListRecordItems(tailLabel, tailFeatures));
+  return [firstItem].concat(
+    collectListRecordItems(recurse, tailLabel, tailFeatures),
+  );
 };
 
-const printListRecord = (label, features) => {
-  const items = collectListRecordItems(label, features).filter(x => !!x);
+const printListRecord = (recurse, label, features) => {
+  const items = collectListRecordItems(recurse, label, features).filter(
+    x => !!x,
+  );
   return `[${items.join(" ")}]`;
 };
 
-const printTupleRecord = (label, features) => {
+const printTupleRecord = (recurse, label, features) => {
   const printedFeatures = features
     .entrySeq()
     .sortBy(entry => parseInt(entry[0]))
-    .map(entry => `${printValuePosition(entry[1])}`)
+    .map(entry => `${printValue(recurse, entry[1]).abbreviated}`)
     .join(" ");
 
   return `${printLabel(label)}(${printedFeatures})`;
-};
-
-const printGenericRecord = (label, features) => {
-  const printedFeatures = features
-    .entrySeq()
-    .sortBy(entry => entry[0])
-    .map(entry => `${entry[0]}:${printValuePosition(entry[1])}`)
-    .join(" ");
-
-  return `${printLabel(label)}(${printedFeatures})`;
-};
-
-const printSpecificRecord = (label, features) => {
-  if (features.isEmpty()) {
-    return printLabel(label);
-  }
-
-  if (label === "|") {
-    return printListRecord(label, features);
-  }
-
-  if (features.keySeq().every(key => isInteger(key))) {
-    return printTupleRecord(label, features);
-  }
-
-  return printGenericRecord(label, features);
 };
 
 export default (recurse, node) => {
   const value = node.get("value");
   const label = value.get("label");
   const features = value.get("features");
-  const result = `${printSpecificRecord(label, features)}`;
-  return {
-    abbreviated: result,
-    full: result,
-  };
+  if (features.isEmpty()) {
+    const printedLabel = printLabel(label);
+    return { abbreviated: printedLabel, full: printedLabel };
+  }
+
+  if (label === "|") {
+    return {
+      abbreviated: printListRecord(recurse, label, features),
+      full: printGenericRecord(recurse, label, features).full,
+    };
+  }
+
+  if (features.keySeq().every(key => isInteger(key))) {
+    return {
+      abbreviated: printTupleRecord(recurse, label, features),
+      full: printGenericRecord(recurse, label, features).full,
+    };
+  }
+
+  return printGenericRecord(recurse, label, features);
 };

--- a/app/oz/unification/record.js
+++ b/app/oz/unification/record.js
@@ -20,9 +20,9 @@ export default (unify, sigma, equivalenceClassX, equivalenceClassY) => {
   }
 
   return xFeatures.reduce((updatedSigma, feature) => {
-    const xVariable = xValue.getIn(["features", feature]);
-    const yVariable = yValue.getIn(["features", feature]);
+    const lhsContents = xValue.getIn(["features", feature]);
+    const rhsContents = yValue.getIn(["features", feature]);
 
-    return unify(updatedSigma, xVariable, yVariable);
+    return unify(updatedSigma, lhsContents, rhsContents);
   }, sigma);
 };

--- a/app/oz/value_creation/index.js
+++ b/app/oz/value_creation/index.js
@@ -11,5 +11,5 @@ export const valueCreators = {
 
 export const createValue = (environment, literal) => {
   const creator = valueCreators[literal.get("type")];
-  return creator(environment, literal);
+  return creator(createValue, environment, literal);
 };

--- a/app/oz/value_creation/number.js
+++ b/app/oz/value_creation/number.js
@@ -1,3 +1,3 @@
-export default (environment, literal) => {
+export default (recurse, environment, literal) => {
   return literal.set("node", "value");
 };

--- a/app/oz/value_creation/procedure.js
+++ b/app/oz/value_creation/procedure.js
@@ -1,7 +1,7 @@
 import { buildEnvironment } from "../machine/build";
 import { collectFreeIdentifiers } from "../free_identifiers";
 
-export default (environment, literal) => {
+export default (recurse, environment, literal) => {
   const freeIdentifiers = collectFreeIdentifiers(literal);
 
   const context = freeIdentifiers.reduce((accumulator, identifier) => {

--- a/app/oz/value_creation/record.js
+++ b/app/oz/value_creation/record.js
@@ -1,10 +1,14 @@
-export default (environment, literal) => {
+export default (recurse, environment, literal) => {
   return literal
     .set("node", "value")
     .updateIn(["value", "features"], features => {
       return features.map(feature => {
-        const identifier = feature.get("identifier");
-        return environment.get(identifier);
+        if (feature.get("node") === "identifier") {
+          const identifier = feature.get("identifier");
+          return environment.get(identifier);
+        }
+
+        return recurse(environment, feature);
       });
     });
 };

--- a/app/ui/code/kernel.jsx
+++ b/app/ui/code/kernel.jsx
@@ -8,6 +8,7 @@ import { print } from "../../oz/print";
 
 export class Kernel extends React.Component {
   componentDidMount() {
+    const value = this.props.compilation ? this.props.source : "";
     const codeMirrorOptions = {
       mode: "oz",
       theme: "elegant",
@@ -15,14 +16,15 @@ export class Kernel extends React.Component {
       lineNumbers: true,
       lineWrapping: true,
       readOnly: true,
-      value: this.props.source,
+      value,
     };
     this.editor = new CodeMirror(this.editorElement, codeMirrorOptions);
     setTimeout(() => this.editor.refresh(), 1000);
   }
 
   componentWillReceiveProps(nextProps) {
-    this.editor.setValue(nextProps.source);
+    const value = nextProps.compilation ? nextProps.source : "";
+    this.editor.setValue(value);
   }
 
   render() {
@@ -37,6 +39,7 @@ export class Kernel extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  compilation: state.getIn(["parse", "compiled"]),
   source: print(state.getIn(["parse", "compiled"])).full,
 });
 

--- a/specs/built_ins/record_selection_spec.js
+++ b/specs/built_ins/record_selection_spec.js
@@ -162,5 +162,18 @@ describe("The record selection built-in", () => {
       expect(evaluation.get("value")).toEqual(valueNumber(3));
       expect(evaluation.get("variable")).toEqual(buildVariable("n", 0));
     });
+
+    it("returns the value and no variable when it's a nested record", () => {
+      const args = Immutable.fromJS([
+        { value: valueRecord("person", { name: valueNumber(30) }) },
+        { value: valueAtom("name") },
+      ]);
+      const sigma = buildSigma();
+
+      const evaluation = operator.evaluate(args, sigma);
+
+      expect(evaluation.get("value")).toEqual(valueNumber(30));
+      expect(evaluation.get("variable")).toEqual(undefined);
+    });
   });
 });

--- a/specs/compilation/record_spec.js
+++ b/specs/compilation/record_spec.js
@@ -1,6 +1,12 @@
 import Immutable from "immutable";
 import { compile } from "../../app/oz/compilation";
-import { literalRecord } from "../../app/oz/machine/literals";
+import {
+  literalRecord,
+  literalProcedure,
+  literalNumber,
+} from "../../app/oz/machine/literals";
+import { skipStatementSyntax } from "../../app/oz/machine/statementSyntax";
+import { skipStatement } from "../../app/oz/machine/statements";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
 describe("Compiling record values", () => {
@@ -15,5 +21,22 @@ describe("Compiling record values", () => {
     });
 
     expect(compile(value)).toEqual(value);
+  });
+
+  it("compiles nested records appropriately", () => {
+    const value = literalRecord("person", {
+      operation: literalProcedure(
+        [lexicalIdentifier("A")],
+        skipStatementSyntax(),
+      ),
+      number: literalNumber(30),
+    });
+
+    expect(compile(value)).toEqual(
+      literalRecord("person", {
+        operation: literalProcedure([lexicalIdentifier("A")], skipStatement()),
+        number: literalNumber(30),
+      }),
+    );
   });
 });

--- a/specs/entailment/record_spec.js
+++ b/specs/entailment/record_spec.js
@@ -69,6 +69,21 @@ describe("Entailing record values", () => {
     expect(result.get("waitCondition")).toEqual(undefined);
   });
 
+  it("returns true when features point to different variables with the same values", () => {
+    const args = Immutable.fromJS([
+      { value: valueRecord("person", { age: buildVariable("n", 0) }) },
+      { value: valueRecord("person", { age: buildVariable("n", 1) }) },
+    ]);
+    const sigma = buildSigma(
+      buildEquivalenceClass(valueNumber(30), buildVariable("n", 0)),
+      buildEquivalenceClass(valueNumber(30), buildVariable("n", 1)),
+    );
+    const result = entail(args, sigma);
+    expect(result.get("value")).toEqual(true);
+    expect(result.get("variable")).toEqual(undefined);
+    expect(result.get("waitCondition")).toEqual(undefined);
+  });
+
   it("returns undefined when features point to different unbound variables", () => {
     const args = Immutable.fromJS([
       { value: valueRecord("person", { age: buildVariable("n", 0) }) },
@@ -112,5 +127,35 @@ describe("Entailing record values", () => {
     expect(result.get("value")).toEqual(undefined);
     expect(result.get("variable")).toEqual(undefined);
     expect(result.get("waitCondition")).toEqual(buildVariable("n", 1));
+  });
+
+  it("returns true when there's a nested value which is the same as a variable value", () => {
+    const args = Immutable.fromJS([
+      {
+        value: valueRecord("person", {
+          age: buildVariable("n", 0),
+          address: valueRecord("address", { number: valueNumber(1200) }),
+        }),
+      },
+      {
+        value: valueRecord("person", {
+          age: valueNumber(30),
+          address: buildVariable("a", 0),
+        }),
+      },
+    ]);
+    const sigma = buildSigma(
+      buildEquivalenceClass(valueNumber(30), buildVariable("n", 0)),
+      buildEquivalenceClass(
+        valueRecord("address", { number: buildVariable("n", 1) }),
+        buildVariable("a", 0),
+      ),
+      buildEquivalenceClass(valueNumber(1200), buildVariable("n", 1)),
+    );
+
+    const result = entail(args, sigma);
+    expect(result.get("value")).toEqual(true);
+    expect(result.get("variable")).toEqual(undefined);
+    expect(result.get("waitCondition")).toEqual(undefined);
   });
 });

--- a/specs/free_identifiers/number_spec.js
+++ b/specs/free_identifiers/number_spec.js
@@ -1,0 +1,14 @@
+import Immutable from "immutable";
+import { collectFreeIdentifiers } from "../../app/oz/free_identifiers";
+import { literalNumber } from "../../app/oz/machine/literals";
+
+describe("Collecting free identifiers in a number literal", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("always returns an empty set", () => {
+    const literal = literalNumber(3);
+    expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set());
+  });
+});

--- a/specs/free_identifiers/procedure_spec.js
+++ b/specs/free_identifiers/procedure_spec.js
@@ -1,0 +1,26 @@
+import Immutable from "immutable";
+import { collectFreeIdentifiers } from "../../app/oz/free_identifiers";
+import { literalProcedure } from "../../app/oz/machine/literals";
+import {
+  bindingStatement,
+  sequenceStatement,
+} from "../../app/oz/machine/statements";
+import { lexicalIdentifier } from "../../app/oz/machine/lexical";
+
+describe("Collecting free identifiers in a number literal", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("collects all the identifiers in the procedure", () => {
+    const literal = literalProcedure(
+      [lexicalIdentifier("A"), lexicalIdentifier("B")],
+      sequenceStatement(
+        bindingStatement(lexicalIdentifier("Y"), lexicalIdentifier("A")),
+        bindingStatement(lexicalIdentifier("B"), lexicalIdentifier("Z")),
+      ),
+    );
+
+    expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set(["Y", "Z"]));
+  });
+});

--- a/specs/free_identifiers/record_spec.js
+++ b/specs/free_identifiers/record_spec.js
@@ -1,6 +1,6 @@
 import Immutable from "immutable";
 import { collectFreeIdentifiers } from "../../app/oz/free_identifiers";
-import { literalRecord } from "../../app/oz/machine/literals";
+import { literalRecord, literalNumber } from "../../app/oz/machine/literals";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
 describe("Collecting free identifiers in a record literal", () => {
@@ -12,6 +12,18 @@ describe("Collecting free identifiers in a record literal", () => {
     const literal = literalRecord("person", {
       age: lexicalIdentifier("A"),
       name: lexicalIdentifier("N"),
+    });
+
+    expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set(["A", "N"]));
+  });
+
+  it("collects all the nested identifiers in the values", () => {
+    const literal = literalRecord("person", {
+      age: lexicalIdentifier("A"),
+      address: literalRecord("address", {
+        number: lexicalIdentifier("N"),
+        floor: literalNumber(3),
+      }),
     });
 
     expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set(["A", "N"]));

--- a/specs/free_identifiers/record_spec.js
+++ b/specs/free_identifiers/record_spec.js
@@ -1,0 +1,19 @@
+import Immutable from "immutable";
+import { collectFreeIdentifiers } from "../../app/oz/free_identifiers";
+import { literalRecord } from "../../app/oz/machine/literals";
+import { lexicalIdentifier } from "../../app/oz/machine/lexical";
+
+describe("Collecting free identifiers in a record literal", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("collects all the identifiers in the record", () => {
+    const literal = literalRecord("person", {
+      age: lexicalIdentifier("A"),
+      name: lexicalIdentifier("N"),
+    });
+
+    expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set(["A", "N"]));
+  });
+});

--- a/specs/free_identifiers/value_creation_spec.js
+++ b/specs/free_identifiers/value_creation_spec.js
@@ -1,70 +1,28 @@
 import Immutable from "immutable";
 import { collectFreeIdentifiers } from "../../app/oz/free_identifiers";
-import {
-  valueCreationStatement,
-  bindingStatement,
-  sequenceStatement,
-} from "../../app/oz/machine/statements";
+import { valueCreationStatement } from "../../app/oz/machine/statements";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 import { literalExpression } from "../../app/oz/machine/expressions";
-import {
-  literalNumber,
-  literalRecord,
-  literalProcedure,
-} from "../../app/oz/machine/literals";
+import { literalRecord } from "../../app/oz/machine/literals";
 
 describe("Collecting free identifiers in a value creation statement", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  describe("when the created value is an integer", () => {
-    it("collects the lhs identifier", () => {
-      const statement = valueCreationStatement(
-        lexicalIdentifier("X"),
-        literalExpression(literalNumber(155)),
-      );
+  it("collects the lhs identifier and all the identifiers in the literal", () => {
+    const statement = valueCreationStatement(
+      lexicalIdentifier("X"),
+      literalExpression(
+        literalRecord("person", {
+          age: lexicalIdentifier("A"),
+          name: lexicalIdentifier("N"),
+        }),
+      ),
+    );
 
-      expect(collectFreeIdentifiers(statement)).toEqual(Immutable.Set(["X"]));
-    });
-  });
-
-  describe("when the created value is a record", () => {
-    it("collects the lhs identifier and all the identifiers in the record", () => {
-      const statement = valueCreationStatement(
-        lexicalIdentifier("X"),
-        literalExpression(
-          literalRecord("person", {
-            age: lexicalIdentifier("A"),
-            name: lexicalIdentifier("N"),
-          }),
-        ),
-      );
-
-      expect(collectFreeIdentifiers(statement)).toEqual(
-        Immutable.Set(["X", "A", "N"]),
-      );
-    });
-  });
-
-  describe("when the created value is a procedure", () => {
-    it("collects the lhs identifier and all the identifiers in the procedure", () => {
-      const statement = valueCreationStatement(
-        lexicalIdentifier("X"),
-        literalExpression(
-          literalProcedure(
-            [lexicalIdentifier("A"), lexicalIdentifier("B")],
-            sequenceStatement(
-              bindingStatement(lexicalIdentifier("Y"), lexicalIdentifier("A")),
-              bindingStatement(lexicalIdentifier("B"), lexicalIdentifier("Z")),
-            ),
-          ),
-        ),
-      );
-
-      expect(collectFreeIdentifiers(statement)).toEqual(
-        Immutable.Set(["X", "Y", "Z"]),
-      );
-    });
+    expect(collectFreeIdentifiers(statement)).toEqual(
+      Immutable.Set(["X", "A", "N"]),
+    );
   });
 });

--- a/specs/parser/literals/lists_spec.js
+++ b/specs/parser/literals/lists_spec.js
@@ -2,7 +2,7 @@ import Immutable from "immutable";
 import { parserFor } from "../../../app/oz/parser";
 import literalGrammar from "../../../app/oz/grammar/literals.ne";
 import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
-import { literalList } from "../../../app/oz/machine/literals";
+import { literalList, literalNumber } from "../../../app/oz/machine/literals";
 
 const parse = parserFor(literalGrammar);
 
@@ -34,6 +34,16 @@ describe("Parsing list literals", () => {
   it("handles lists with more than 1 same element correctly", () => {
     expect(parse("[X A Y Z Z A]")).toEqual(
       identifiersList(["X", "A", "Y", "Z", "Z", "A"]),
+    );
+  });
+
+  it("handles nested literals", () => {
+    expect(parse("[1 2 [3 4]]")).toEqual(
+      literalList([
+        literalNumber(1),
+        literalNumber(2),
+        literalList([literalNumber(3), literalNumber(4)]),
+      ]),
     );
   });
 });

--- a/specs/parser/literals/record_spec.js
+++ b/specs/parser/literals/record_spec.js
@@ -1,6 +1,6 @@
 import Immutable from "immutable";
 import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
-import { literalRecord } from "../../../app/oz/machine/literals";
+import { literalRecord, literalNumber } from "../../../app/oz/machine/literals";
 import { parserFor } from "../../../app/oz/parser";
 import literalGrammar from "../../../app/oz/grammar/literals.ne";
 
@@ -58,6 +58,18 @@ describe("Parsing record literals", () => {
       literalRecord("andthen", {
         a: lexicalIdentifier("X"),
         b: lexicalIdentifier("Y"),
+      }),
+    );
+  });
+
+  it("handles nested literals", () => {
+    expect(parse("label(age:30 name:N address:address(number:1200))")).toEqual(
+      literalRecord("label", {
+        age: literalNumber(30),
+        name: lexicalIdentifier("N"),
+        address: literalRecord("address", {
+          number: literalNumber(1200),
+        }),
       }),
     );
   });

--- a/specs/parser/literals/string_spec.js
+++ b/specs/parser/literals/string_spec.js
@@ -10,7 +10,11 @@ describe("Parsing string literals", () => {
     jasmine.addCustomEqualityTester(Immutable.is);
   });
 
-  it("handles parsing correctly", () => {
+  it("handles parsing simple strings correctly", () => {
+    expect(parse('"ABC"')).toEqual(literalString("ABC"));
+  });
+
+  it("handles parsing complex strings correctly", () => {
     expect(parse('"a \\\\\\nSTRING"')).toEqual(literalString("a \\\nSTRING"));
   });
 });

--- a/specs/parser/literals/tuple_spec.js
+++ b/specs/parser/literals/tuple_spec.js
@@ -1,6 +1,6 @@
 import Immutable from "immutable";
 import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
-import { literalTuple } from "../../../app/oz/machine/literals";
+import { literalTuple, literalNumber } from "../../../app/oz/machine/literals";
 import { parserFor } from "../../../app/oz/parser";
 import literalGrammar from "../../../app/oz/grammar/literals.ne";
 
@@ -44,6 +44,16 @@ describe("Parsing tuple literals", () => {
   it("handles a quoted label syntax", () => {
     expect(parse("'andthen'(X Y)")).toEqual(
       literalTuple("andthen", [lexicalIdentifier("X"), lexicalIdentifier("Y")]),
+    );
+  });
+
+  it("handles nested literals", () => {
+    expect(parse("label(30 50 Z)")).toEqual(
+      literalTuple("label", [
+        literalNumber(30),
+        literalNumber(50),
+        lexicalIdentifier("Z"),
+      ]),
     );
   });
 });

--- a/specs/print/record_literal_spec.js
+++ b/specs/print/record_literal_spec.js
@@ -5,6 +5,8 @@ import {
   literalAtom,
   literalBoolean,
   literalTuple,
+  literalList,
+  literalNumber,
 } from "../../app/oz/machine/literals";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
@@ -16,12 +18,12 @@ describe("Printing a record literal", () => {
   it("Returns the appropriate string for standard records", () => {
     const literal = literalRecord("person", {
       name: lexicalIdentifier("N"),
-      age: lexicalIdentifier("Age"),
+      age: literalNumber(30),
     });
     const result = print(literal, 2);
 
-    expect(result.abbreviated).toEqual("person(age:Age name:N)");
-    expect(result.full).toEqual("person(age:Age name:N)");
+    expect(result.abbreviated).toEqual("person(age:30 name:N)");
+    expect(result.full).toEqual("person(age:30 name:N)");
   });
 
   it("Returns the appropriate string for atoms", () => {
@@ -43,12 +45,34 @@ describe("Printing a record literal", () => {
   it("Returns the appropriate string for generic tuples", () => {
     const literal = literalTuple("person", [
       lexicalIdentifier("X"),
-      lexicalIdentifier("Y"),
-      lexicalIdentifier("Z"),
+      literalNumber(30),
     ]);
     const result = print(literal, 2);
 
-    expect(result.abbreviated).toEqual("person(X Y Z)");
-    expect(result.full).toEqual("person(X Y Z)");
+    expect(result.abbreviated).toEqual("person(X 30)");
+    expect(result.full).toEqual("person(X 30)");
+  });
+
+  it("Returns the appropriate string for lists", () => {
+    const literal = literalList([lexicalIdentifier("X"), literalNumber(30)]);
+    const result = print(literal, 2);
+
+    expect(result.abbreviated).toEqual("[X 30]");
+    expect(result.full).toEqual("[X 30]");
+  });
+
+  it("Returns the appropriate string for nested recursive structures", () => {
+    const literal = literalRecord("person", {
+      age: literalNumber(30),
+      address: literalRecord("address", {
+        number: literalNumber(1300),
+      }),
+    });
+    const result = print(literal, 2);
+
+    expect(result.abbreviated).toEqual(
+      "person(address:address(number:1300) age:30)",
+    );
+    expect(result.full).toEqual("person(address:address(number:1300) age:30)");
   });
 });

--- a/specs/print/record_literal_spec.js
+++ b/specs/print/record_literal_spec.js
@@ -5,7 +5,6 @@ import {
   literalAtom,
   literalBoolean,
   literalTuple,
-  literalList,
 } from "../../app/oz/machine/literals";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
@@ -51,17 +50,5 @@ describe("Printing a record literal", () => {
 
     expect(result.abbreviated).toEqual("person(X Y Z)");
     expect(result.full).toEqual("person(X Y Z)");
-  });
-
-  it("Returns the appropriate string for generic lists", () => {
-    const literal = literalList([
-      lexicalIdentifier("X"),
-      lexicalIdentifier("Y"),
-      lexicalIdentifier("Z"),
-    ]);
-    const result = print(literal, 2);
-
-    expect(result.abbreviated).toEqual("[X Y Z]");
-    expect(result.full).toEqual("[X Y Z]");
   });
 });

--- a/specs/print/record_value_spec.js
+++ b/specs/print/record_value_spec.js
@@ -6,8 +6,9 @@ import {
   valueBoolean,
   valueTuple,
   valueList,
+  valueNumber,
 } from "../../app/oz/machine/values";
-import { lexicalIdentifier } from "../../app/oz/machine/lexical";
+import { buildVariable } from "../../app/oz/machine/build";
 
 describe("Printing a record value", () => {
   beforeEach(() => {
@@ -16,13 +17,13 @@ describe("Printing a record value", () => {
 
   it("Returns the appropriate string for standard records", () => {
     const value = valueRecord("person", {
-      name: lexicalIdentifier("N"),
-      age: lexicalIdentifier("Age"),
+      name: buildVariable("n", 0),
+      age: valueNumber(30),
     });
     const result = print(value, 2);
 
-    expect(result.abbreviated).toEqual("person(age:Age name:N)");
-    expect(result.full).toEqual("person(age:Age name:N)");
+    expect(result.abbreviated).toEqual("person(age:30 name:n0)");
+    expect(result.full).toEqual("person(age:30 name:n0)");
   });
 
   it("Returns the appropriate string for atoms", () => {
@@ -43,25 +44,35 @@ describe("Printing a record value", () => {
 
   it("Returns the appropriate string for generic tuples", () => {
     const value = valueTuple("person", [
-      lexicalIdentifier("X"),
-      lexicalIdentifier("Y"),
-      lexicalIdentifier("Z"),
+      buildVariable("x", 0),
+      valueNumber(30),
     ]);
     const result = print(value, 2);
 
-    expect(result.abbreviated).toEqual("person(X Y Z)");
-    expect(result.full).toEqual("person(X Y Z)");
+    expect(result.abbreviated).toEqual("person(x0 30)");
+    expect(result.full).toEqual("person(1:x0 2:30)");
   });
 
-  it("Returns the appropriate string for generic lists", () => {
-    const value = valueList([
-      lexicalIdentifier("X"),
-      lexicalIdentifier("Y"),
-      lexicalIdentifier("Z"),
-    ]);
+  it("Returns the appropriate string for lists", () => {
+    const value = valueList([buildVariable("x", 0), valueNumber(30)]);
     const result = print(value, 2);
 
-    expect(result.abbreviated).toEqual("[X Y Z]");
-    expect(result.full).toEqual("[X Y Z]");
+    expect(result.abbreviated).toEqual("[x0 30]");
+    expect(result.full).toEqual("'|'(1:x0 2:'|'(1:30 2:nil))");
+  });
+
+  it("Returns the appropriate string for nested recursive structures", () => {
+    const value = valueRecord("person", {
+      age: valueNumber(30),
+      address: valueRecord("address", {
+        number: valueNumber(1300),
+      }),
+    });
+    const result = print(value, 2);
+
+    expect(result.abbreviated).toEqual(
+      "person(address:address(number:1300) age:30)",
+    );
+    expect(result.full).toEqual("person(address:address(number:1300) age:30)");
   });
 });

--- a/specs/unification/record_spec.js
+++ b/specs/unification/record_spec.js
@@ -142,6 +142,50 @@ describe("Unifying records", () => {
     );
   });
 
+  it("Unifies correctly nested recursive unifications", () => {
+    const sigma = buildSigma(
+      buildEquivalenceClass(
+        valueRecord("person", { address: buildVariable("y", 0) }),
+        buildVariable("x", 0),
+        buildVariable("x", 1),
+      ),
+      buildEquivalenceClass(
+        valueRecord("address", { street: buildVariable("a", 0) }),
+        buildVariable("y", 0),
+      ),
+      buildEquivalenceClass(
+        valueRecord("person", {
+          address: valueRecord("address", { street: buildVariable("b", 0) }),
+        }),
+        buildVariable("z", 0),
+      ),
+      buildEquivalenceClass(undefined, buildVariable("a", 0)),
+      buildEquivalenceClass(undefined, buildVariable("b", 0)),
+    );
+
+    const unifiedSigma = buildSigma(
+      buildEquivalenceClass(
+        undefined,
+        buildVariable("a", 0),
+        buildVariable("b", 0),
+      ),
+      buildEquivalenceClass(
+        valueRecord("address", { street: buildVariable("a", 0) }),
+        buildVariable("y", 0),
+      ),
+      buildEquivalenceClass(
+        valueRecord("person", { address: buildVariable("y", 0) }),
+        buildVariable("x", 0),
+        buildVariable("x", 1),
+        buildVariable("z", 0),
+      ),
+    );
+
+    expect(unify(sigma, buildVariable("x", 0), buildVariable("z", 0))).toEqual(
+      unifiedSigma,
+    );
+  });
+
   it("fails if the records have different labels", () => {
     const sigma = buildSigma(
       buildEquivalenceClass(

--- a/specs/value_creation/record_spec.js
+++ b/specs/value_creation/record_spec.js
@@ -29,7 +29,7 @@ describe("Creating record values in the sigma", () => {
     );
   });
 
-  it("creates a sigma nested record value", () => {
+  it("creates a nested record value", () => {
     const environment = buildEnvironment({
       X: buildVariable("x", 0),
       Y: buildVariable("y", 0),

--- a/specs/value_creation/record_spec.js
+++ b/specs/value_creation/record_spec.js
@@ -1,8 +1,8 @@
 import Immutable from "immutable";
 import { createValue } from "../../app/oz/machine/sigma";
 import { buildEnvironment, buildVariable } from "../../app/oz/machine/build";
-import { literalRecord } from "../../app/oz/machine/literals";
-import { valueRecord } from "../../app/oz/machine/values";
+import { literalRecord, literalNumber } from "../../app/oz/machine/literals";
+import { valueRecord, valueNumber } from "../../app/oz/machine/values";
 import { lexicalIdentifier } from "../../app/oz/machine/lexical";
 
 describe("Creating record values in the sigma", () => {
@@ -24,6 +24,25 @@ describe("Creating record values in the sigma", () => {
     expect(createValue(environment, literal)).toEqual(
       valueRecord("person", {
         age: buildVariable("x", 0),
+        name: buildVariable("y", 0),
+      }),
+    );
+  });
+
+  it("creates a sigma nested record value", () => {
+    const environment = buildEnvironment({
+      X: buildVariable("x", 0),
+      Y: buildVariable("y", 0),
+    });
+
+    const literal = literalRecord("person", {
+      age: literalNumber(30),
+      name: lexicalIdentifier("Y"),
+    });
+
+    expect(createValue(environment, literal)).toEqual(
+      valueRecord("person", {
+        age: valueNumber(30),
         name: buildVariable("y", 0),
       }),
     );


### PR DESCRIPTION
## Summary of changes

* Implements nested and partial literals. This includes list literals, and other generic nested literals.
* Implements nested and partial store values. The features of a record value now can contain variables or nested inline values.
* Merged all of the `xToVariable` and `unifyXandY` methods into a single `convertToVariable` and `unify` method. The logic was mostly the same across all the instances, and having it separate complicates things when having nested values.
* Fixes a small regression on the kernel display when the compilation is null

## Related issues

* Closes kozily/admin#92
* Closes kozily/admin#128
