### PR TITLE
151 - Adds support for integers on record feature selection rhs

### DIFF
--- a/app/oz/built_ins/validations.js
+++ b/app/oz/built_ins/validations.js
@@ -13,6 +13,13 @@ export const typedOperator = type => args => {
   );
 };
 
+export const typedArgument = (type, index) => args => {
+  return (
+    args.some(arg => arg.get("value") === undefined) ||
+    args.getIn([index, "value", "type"]) === type
+  );
+};
+
 export const dividendNotZero = args => {
   return (
     args.getIn([1, "value"]) === undefined ||

--- a/specs/parser/expressions/record_feature_selection_spec.js
+++ b/specs/parser/expressions/record_feature_selection_spec.js
@@ -1,5 +1,5 @@
 import Immutable from "immutable";
-import { literalAtom } from "../../../app/oz/machine/literals";
+import { literalAtom, literalNumber } from "../../../app/oz/machine/literals";
 import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
 import {
   operatorExpression,
@@ -26,6 +26,16 @@ describe("Parsing record feature selection expressions", () => {
     );
   });
 
+  it("parses successfully when rhs is a number", () => {
+    expect(parse("X.1")).toEqual(
+      operatorExpression(
+        ".",
+        identifierExpression(lexicalIdentifier("X")),
+        literalExpression(literalNumber(1)),
+      ),
+    );
+  });
+
   it("parses successfully when rhs is an identifier", () => {
     expect(parse("X.F")).toEqual(
       operatorExpression(
@@ -36,7 +46,7 @@ describe("Parsing record feature selection expressions", () => {
     );
   });
 
-  it("parses sequences successfully", () => {
+  it("parses sequences of atoms successfully", () => {
     expect(parse("X.age.number")).toEqual(
       operatorExpression(
         ".",
@@ -46,6 +56,34 @@ describe("Parsing record feature selection expressions", () => {
           literalExpression(literalAtom("age")),
         ),
         literalExpression(literalAtom("number")),
+      ),
+    );
+  });
+
+  it("parses sequences of identifiers successfully", () => {
+    expect(parse("X.Y.Z")).toEqual(
+      operatorExpression(
+        ".",
+        operatorExpression(
+          ".",
+          identifierExpression(lexicalIdentifier("X")),
+          identifierExpression(lexicalIdentifier("Y")),
+        ),
+        identifierExpression(lexicalIdentifier("Z")),
+      ),
+    );
+  });
+
+  it("parses sequences of integers successfully", () => {
+    expect(parse("X.1.2")).toEqual(
+      operatorExpression(
+        ".",
+        operatorExpression(
+          ".",
+          identifierExpression(lexicalIdentifier("X")),
+          literalExpression(literalNumber(1)),
+        ),
+        literalExpression(literalNumber(2)),
       ),
     );
   });


### PR DESCRIPTION
## Summary of changes

* Record feature selection now supports bare integers in addition to atoms and identifiers on the RHS. This requires custom integer parsing, as we need to support both integers < 255 (chars) and integers > 255 (decimal integers).
* Moves all utility functions to the top of the grammar so that they can be used from anywhere in the file.

## Related issues

* Closes kozily/admin#151