### PR TITLE
90 - Implements cons syntax for tuples

### DIFF
--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -495,7 +495,11 @@ lit_false_literal -> "false" {%
 # Tuple
 ##############################################################################
 
-lit_tuple -> lit_atom_syntax "(" _ lit_list_items _ ")" {%
+lit_tuple ->
+    lit_tuple_generic {% id %}
+  | lit_tuple_cons {% id %}
+
+lit_tuple_generic -> lit_atom_syntax "(" _ lit_list_items _ ")" {%
   function(d, position, reject) {
     var label = d[0];
     var features = d[3].reduce(function(result, item, index) {
@@ -505,6 +509,32 @@ lit_tuple -> lit_atom_syntax "(" _ lit_list_items _ ")" {%
     return litBuildRecord(label, features);
   }
 %}
+
+lit_tuple_cons -> lit_tuple_cons_item ("#" lit_tuple_cons_item):+ {%
+  function(d) {
+    var label = "#";
+    var featureList = [d[0]].concat(d[1].map(function(item) {
+      return item[1];
+    }));
+    var features = featureList.reduce(function(result, item, index) {
+      result[++index] = item;
+      return result;
+    }, {});
+
+    return litBuildRecord(label, features);
+  }
+%}
+
+lit_tuple_cons_item ->
+    ids_identifier {% id %}
+  | lit_atom {% id %}
+  | lit_boolean {% id %}
+  | lit_string {% id %}
+  | lit_char {% id %}
+  | lit_integer {% id %}
+  | lit_float {% id %}
+  | lit_list {% id %}
+  | lit_procedure {% id %}
 
 ##############################################################################
 # List

--- a/app/oz/print/literals/record.js
+++ b/app/oz/print/literals/record.js
@@ -90,14 +90,30 @@ const printListRecord = (recurse, label, features) => {
   return printConsListRecord(recurse, label, features);
 };
 
-const printTupleRecord = (recurse, label, features) => {
+const printConsTupleRecord = (recurse, label, features) => {
+  return features
+    .entrySeq()
+    .sortBy(entry => parseInt(entry[0], 10))
+    .map(entry => printValue(recurse, entry[1]).abbreviated)
+    .join("#");
+};
+
+const printGenericTupleRecord = (recurse, label, features) => {
   const printedFeatures = features
     .entrySeq()
-    .sortBy(entry => parseInt(entry[0]))
-    .map(entry => `${printValue(recurse, entry[1]).abbreviated}`)
+    .sortBy(entry => parseInt(entry[0], 10))
+    .map(entry => printValue(recurse, entry[1]).abbreviated)
     .join(" ");
 
   return `${printLabel(label)}(${printedFeatures})`;
+};
+
+const printTupleRecord = (recurse, label, features) => {
+  if (label === "#") {
+    return printConsTupleRecord(recurse, label, features);
+  }
+
+  return printGenericTupleRecord(recurse, label, features);
 };
 
 export default (recurse, node) => {

--- a/app/oz/print/values/record.js
+++ b/app/oz/print/values/record.js
@@ -90,14 +90,30 @@ const printListRecord = (recurse, label, features) => {
   return printConsListRecord(recurse, label, features);
 };
 
-const printTupleRecord = (recurse, label, features) => {
+const printConsTupleRecord = (recurse, label, features) => {
+  return features
+    .entrySeq()
+    .sortBy(entry => parseInt(entry[0], 10))
+    .map(entry => printValue(recurse, entry[1]).abbreviated)
+    .join("#");
+};
+
+const printGenericTupleRecord = (recurse, label, features) => {
   const printedFeatures = features
     .entrySeq()
-    .sortBy(entry => parseInt(entry[0]))
-    .map(entry => `${printValue(recurse, entry[1]).abbreviated}`)
+    .sortBy(entry => parseInt(entry[0], 10))
+    .map(entry => printValue(recurse, entry[1]).abbreviated)
     .join(" ");
 
   return `${printLabel(label)}(${printedFeatures})`;
+};
+
+const printTupleRecord = (recurse, label, features) => {
+  if (label === "#") {
+    return printConsTupleRecord(recurse, label, features);
+  }
+
+  return printGenericTupleRecord(recurse, label, features);
 };
 
 export default (recurse, node) => {

--- a/specs/parser/literals/tuple_spec.js
+++ b/specs/parser/literals/tuple_spec.js
@@ -56,4 +56,20 @@ describe("Parsing tuple literals", () => {
       ]),
     );
   });
+
+  it("handles hashed literals", () => {
+    expect(parse("H#T")).toEqual(
+      literalTuple("#", [lexicalIdentifier("H"), lexicalIdentifier("T")]),
+    );
+  });
+
+  it("handles repeated hashed literals", () => {
+    expect(parse("1#2#T")).toEqual(
+      literalTuple("#", [
+        literalNumber(1),
+        literalNumber(2),
+        lexicalIdentifier("T"),
+      ]),
+    );
+  });
 });

--- a/specs/print/record_literal_spec.js
+++ b/specs/print/record_literal_spec.js
@@ -54,6 +54,18 @@ describe("Printing a record literal", () => {
     expect(result.full).toEqual("person(X 30)");
   });
 
+  it("Returns the appropriate string for cons tuples", () => {
+    const literal = literalTuple("#", [
+      lexicalIdentifier("X"),
+      literalNumber(30),
+      literalNumber(35),
+    ]);
+    const result = print(literal, 2);
+
+    expect(result.abbreviated).toEqual("X#30#35");
+    expect(result.full).toEqual("X#30#35");
+  });
+
   it("Returns the appropriate string for lists", () => {
     const literal = literalList([lexicalIdentifier("X"), literalNumber(30)]);
     const result = print(literal, 2);

--- a/specs/print/record_value_spec.js
+++ b/specs/print/record_value_spec.js
@@ -54,6 +54,18 @@ describe("Printing a record value", () => {
     expect(result.full).toEqual("person(1:x0 2:30)");
   });
 
+  it("Returns the appropriate string for cons tuples", () => {
+    const value = valueTuple("#", [
+      buildVariable("x", 0),
+      valueNumber(30),
+      valueNumber(35),
+    ]);
+    const result = print(value, 2);
+
+    expect(result.abbreviated).toEqual("x0#30#35");
+    expect(result.full).toEqual("'#'(1:x0 2:30 3:35)");
+  });
+
   it("Returns the appropriate string for lists", () => {
     const value = valueList([buildVariable("x", 0), valueNumber(30)]);
     const result = print(value, 2);


### PR DESCRIPTION
## Summary of changes

* Implements the cons syntax for tuples `A#B#C`.

## Related issues

* Closes kozily/admin#90