### PR TITLE
158 - Implements generic pattern matching

### DIFF
--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -746,13 +746,17 @@ lit_procedure_args ->
 ##############################################################################
 # PAT - PATTERNS
 ##############################################################################
- pat_pattern ->
-    lit_record {% id %}
+pat_pattern ->
+    ids_identifier {% id %}
+  | lit_char {% id %}
+  | lit_integer {% id %}
+  | lit_float {% id %}
   | lit_atom {% id %}
+  | lit_string {% id %}
   | lit_boolean {% id %}
+  | lit_record {% id %}
   | lit_tuple {% id %}
   | lit_list {% id %}
-
 
 ##############################################################################
 # LIB - UTILITIES

--- a/app/oz/machine/patterns.js
+++ b/app/oz/machine/patterns.js
@@ -1,0 +1,7 @@
+export const patternTypes = {
+  identifier: "identifier",
+  number: "number",
+  record: "record",
+};
+
+export const allPatternTypes = Object.keys(patternTypes);

--- a/app/oz/pattern_match/identifier.js
+++ b/app/oz/pattern_match/identifier.js
@@ -1,0 +1,18 @@
+import { buildEnvironment } from "../machine/build";
+import { convertToVariable } from "../machine/sigma";
+
+export default (recurse, evaluation, pattern, sigma) => {
+  const { sigma: augmentedSigma, variable } = convertToVariable(
+    evaluation,
+    sigma,
+    "patternMatch",
+  );
+
+  return {
+    match: true,
+    additionalBindings: buildEnvironment({
+      [pattern.get("identifier")]: variable,
+    }),
+    sigma: augmentedSigma,
+  };
+};

--- a/app/oz/pattern_match/index.js
+++ b/app/oz/pattern_match/index.js
@@ -1,0 +1,19 @@
+import { patternTypes } from "../machine/patterns";
+import identifier from "./identifier";
+import number from "./number";
+import record from "./record";
+
+export const matchers = {
+  [patternTypes.identifier]: identifier,
+  [patternTypes.number]: number,
+  [patternTypes.record]: record,
+};
+
+export const patternMatch = (evaluation, pattern, sigma) => {
+  const matcher =
+    pattern.get("node") !== "literal"
+      ? matchers[patternTypes.identifier]
+      : matchers[pattern.get("type")];
+
+  return matcher(patternMatch, evaluation, pattern, sigma);
+};

--- a/app/oz/pattern_match/number.js
+++ b/app/oz/pattern_match/number.js
@@ -1,0 +1,21 @@
+import Immutable from "immutable";
+import { valueTypes } from "../machine/values";
+import { buildEnvironment } from "../machine/build";
+
+export default (recurse, evaluation, pattern, sigma) => {
+  const value = evaluation.get("value");
+
+  if (value.get("type") !== valueTypes.number) {
+    return { match: false };
+  }
+
+  if (!Immutable.is(value.get("value"), pattern.get("value"))) {
+    return { match: false };
+  }
+
+  return {
+    match: true,
+    additionalBindings: buildEnvironment(),
+    sigma,
+  };
+};

--- a/app/oz/pattern_match/record.js
+++ b/app/oz/pattern_match/record.js
@@ -1,0 +1,74 @@
+import Immutable from "immutable";
+import { valueTypes } from "../machine/values";
+import { lookupVariableInSigma } from "../machine/sigma";
+import { buildEnvironment } from "../machine/build";
+
+const extractValueAndVariable = (thing, sigma) => {
+  if (thing.get("node") === "value") {
+    return Immutable.fromJS({ value: thing });
+  }
+
+  const value = lookupVariableInSigma(sigma, thing).get("value");
+  return Immutable.fromJS({ value, variable: thing });
+};
+
+export default (recurse, evaluation, pattern, sigma) => {
+  const value = evaluation.get("value");
+
+  if (value.get("type") !== valueTypes.record) {
+    return { match: false };
+  }
+
+  if (value.getIn(["value", "label"]) !== pattern.getIn(["value", "label"])) {
+    return { match: false };
+  }
+
+  const evaluationFeatures = Immutable.Set(
+    value.getIn(["value", "features"]).keySeq(),
+  );
+  const patternFeatures = Immutable.Set(
+    pattern.getIn(["value", "features"]).keySeq(),
+  );
+
+  if (!Immutable.is(evaluationFeatures, patternFeatures)) {
+    return { match: false };
+  }
+
+  const valuePairs = evaluationFeatures.map(x => [
+    value.getIn(["value", "features", x]),
+    pattern.getIn(["value", "features", x]),
+  ]);
+
+  const initialReduction = {
+    match: true,
+    additionalBindings: buildEnvironment(),
+    sigma,
+  };
+
+  const result = valuePairs.reduce((result, [value, pattern]) => {
+    if (!result.match) {
+      return result;
+    }
+
+    const valueAndVariable = extractValueAndVariable(value, result.sigma);
+    const recursiveMatch = recurse(valueAndVariable, pattern, result.sigma);
+
+    if (!recursiveMatch.match) {
+      return { match: false };
+    }
+
+    const accumulatedAdditionalBindings = result.additionalBindings.merge(
+      recursiveMatch.additionalBindings,
+    );
+
+    const accumulatedSigma = result.sigma.union(recursiveMatch.sigma);
+
+    return {
+      match: true,
+      additionalBindings: accumulatedAdditionalBindings,
+      sigma: accumulatedSigma,
+    };
+  }, initialReduction);
+
+  return result;
+};

--- a/app/ui/runtime/code.jsx
+++ b/app/ui/runtime/code.jsx
@@ -1,7 +1,11 @@
 import React from "react";
 
 export const RuntimeCode = props => {
-  return <span style={{ fontFamily: "monospace" }}>{props.children}</span>;
+  return (
+    <span style={{ fontFamily: "monospace", overflow: "scroll" }}>
+      {props.children}
+    </span>
+  );
 };
 
 export default RuntimeCode;

--- a/specs/parser/statements/pattern_matching_spec.js
+++ b/specs/parser/statements/pattern_matching_spec.js
@@ -4,7 +4,16 @@ import {
   identifierExpression,
   operatorExpression,
 } from "../../../app/oz/machine/expressions";
-import { literalRecord } from "../../../app/oz/machine/literals";
+import {
+  literalRecord,
+  literalAtom,
+  literalNumber,
+  literalString,
+  literalBoolean,
+  literalTuple,
+  literalList,
+  literalListItem,
+} from "../../../app/oz/machine/literals";
 import {
   patternMatchingStatementSyntax,
   sequenceStatementSyntax,
@@ -16,47 +25,6 @@ import parse from "../../../app/oz/parser";
 describe("Parsing case statements", () => {
   beforeEach(() => {
     jasmine.addCustomEqualityTester(Immutable.is);
-  });
-
-  it("handles record with label and features", () => {
-    expect(
-      parse("case X of person(name:Name age:Age) then skip skip else skip end"),
-    ).toEqual(
-      patternMatchingStatementSyntax(
-        identifierExpression(lexicalIdentifier("X")),
-        [
-          {
-            pattern: literalRecord("person", {
-              name: lexicalIdentifier("Name"),
-              age: lexicalIdentifier("Age"),
-            }),
-            statement: sequenceStatementSyntax(
-              skipStatementSyntax(),
-              skipStatementSyntax(),
-            ),
-          },
-        ],
-        skipStatementSyntax(),
-      ),
-    );
-  });
-
-  it("handles record with label and no features", () => {
-    expect(parse("case X of person then skip skip else skip end")).toEqual(
-      patternMatchingStatementSyntax(
-        identifierExpression(lexicalIdentifier("X")),
-        [
-          {
-            pattern: literalRecord("person"),
-            statement: sequenceStatementSyntax(
-              skipStatementSyntax(),
-              skipStatementSyntax(),
-            ),
-          },
-        ],
-        skipStatementSyntax(),
-      ),
-    );
   });
 
   it("handles multiple pattern cases", () => {
@@ -129,5 +97,90 @@ describe("Parsing case statements", () => {
         skipStatementSyntax(),
       ),
     );
+  });
+
+  describe("patterns", () => {
+    const simpleCaseWithPattern = pattern =>
+      patternMatchingStatementSyntax(
+        identifierExpression(lexicalIdentifier("X")),
+        [
+          {
+            pattern,
+            statement: skipStatementSyntax(),
+          },
+        ],
+      );
+
+    it("handles identifiers", () => {
+      expect(parse("case X of Y then skip end")).toEqual(
+        simpleCaseWithPattern(lexicalIdentifier("Y")),
+      );
+    });
+
+    it("handles numbers", () => {
+      expect(parse("case X of 12 then skip end")).toEqual(
+        simpleCaseWithPattern(literalNumber(12)),
+      );
+    });
+
+    it("handles atoms", () => {
+      expect(parse("case X of person then skip end")).toEqual(
+        simpleCaseWithPattern(literalAtom("person")),
+      );
+    });
+
+    it("handles strings", () => {
+      expect(parse('case X of "ABC" then skip end')).toEqual(
+        simpleCaseWithPattern(literalString("ABC")),
+      );
+    });
+
+    it("handles booleans", () => {
+      expect(parse("case X of true then skip end")).toEqual(
+        simpleCaseWithPattern(literalBoolean(true)),
+      );
+    });
+
+    it("handles generic records", () => {
+      expect(
+        parse(
+          "case X of person(name:N address:address(number:172 street:S)) then skip end",
+        ),
+      ).toEqual(
+        simpleCaseWithPattern(
+          literalRecord("person", {
+            name: lexicalIdentifier("N"),
+            address: literalRecord("address", {
+              number: literalNumber(172),
+              street: lexicalIdentifier("S"),
+            }),
+          }),
+        ),
+      );
+    });
+
+    it("handles generic tuples", () => {
+      expect(parse("case X of vector(10 Y 20#Z) then skip end")).toEqual(
+        simpleCaseWithPattern(
+          literalTuple("vector", [
+            literalNumber(10),
+            lexicalIdentifier("Y"),
+            literalTuple("#", [literalNumber(20), lexicalIdentifier("Z")]),
+          ]),
+        ),
+      );
+    });
+
+    it("handles generic lists", () => {
+      expect(parse("case X of [10 Y H|T] then skip end")).toEqual(
+        simpleCaseWithPattern(
+          literalList([
+            literalNumber(10),
+            lexicalIdentifier("Y"),
+            literalListItem(lexicalIdentifier("H"), lexicalIdentifier("T")),
+          ]),
+        ),
+      );
+    });
   });
 });

--- a/specs/pattern_match/atom_spec.js
+++ b/specs/pattern_match/atom_spec.js
@@ -1,0 +1,92 @@
+import Immutable from "immutable";
+import { literalExpression } from "../../app/oz/machine/expressions";
+import {
+  literalNumber,
+  literalAtom,
+  literalRecord,
+} from "../../app/oz/machine/literals";
+import { buildSigma, buildEnvironment } from "../../app/oz/machine/build";
+import { evaluate } from "../../app/oz/expression";
+import { patternMatch } from "../../app/oz/pattern_match";
+
+describe("Pattern matching against an atom", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("matches when the atoms are the same", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalAtom("person")),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalAtom("person");
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(true);
+    expect(result.additionalBindings).toEqual(buildEnvironment());
+    expect(result.sigma).toEqual(sigma);
+  });
+
+  it("does not match when the types are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalNumber(10)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalAtom("person");
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the value has features", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalRecord("person", { age: literalNumber(10) })),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalAtom("person");
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the atom labels are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalAtom("people")),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalAtom("person");
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+});

--- a/specs/pattern_match/boolean_spec.js
+++ b/specs/pattern_match/boolean_spec.js
@@ -1,0 +1,92 @@
+import Immutable from "immutable";
+import { literalExpression } from "../../app/oz/machine/expressions";
+import {
+  literalNumber,
+  literalBoolean,
+  literalRecord,
+} from "../../app/oz/machine/literals";
+import { buildSigma, buildEnvironment } from "../../app/oz/machine/build";
+import { evaluate } from "../../app/oz/expression";
+import { patternMatch } from "../../app/oz/pattern_match";
+
+describe("Pattern matching against an boolean", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("matches when the boolean are the same", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalBoolean(true)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalBoolean(true);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(true);
+    expect(result.additionalBindings).toEqual(buildEnvironment());
+    expect(result.sigma).toEqual(sigma);
+  });
+
+  it("does not match when the types are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalNumber(10)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalBoolean(true);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the value has features", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalRecord("person", { age: literalNumber(10) })),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalBoolean(true);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the booleans are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalBoolean(true)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalBoolean(false);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+});

--- a/specs/pattern_match/identifier_spec.js
+++ b/specs/pattern_match/identifier_spec.js
@@ -1,0 +1,56 @@
+import Immutable from "immutable";
+import { literalExpression } from "../../app/oz/machine/expressions";
+import { literalNumber } from "../../app/oz/machine/literals";
+import { valueNumber } from "../../app/oz/machine/values";
+import { lexicalIdentifier } from "../../app/oz/machine/lexical";
+import {
+  buildSigma,
+  buildEquivalenceClass,
+  buildEnvironment,
+  buildVariable,
+  getLastAuxiliaryIdentifier,
+} from "../../app/oz/machine/build";
+import { evaluate } from "../../app/oz/expression";
+import { patternMatch } from "../../app/oz/pattern_match";
+
+describe("Pattern matching against an identifier", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("always matches", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalNumber(2)),
+      environment,
+      sigma,
+    );
+
+    const pattern = lexicalIdentifier("X");
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(true);
+    expect(result.additionalBindings).toEqual(
+      buildEnvironment({
+        X: buildVariable(
+          getLastAuxiliaryIdentifier("patternMatch").get("identifier"),
+          0,
+        ),
+      }),
+    );
+    expect(result.sigma).toEqual(
+      buildSigma(
+        buildEquivalenceClass(
+          valueNumber(2),
+          buildVariable(
+            getLastAuxiliaryIdentifier("patternMatch").get("identifier"),
+            0,
+          ),
+        ),
+      ),
+    );
+  });
+});

--- a/specs/pattern_match/index_spec.js
+++ b/specs/pattern_match/index_spec.js
@@ -1,0 +1,16 @@
+import Immutable from "immutable";
+import { matchers } from "../../app/oz/pattern_match";
+import { allPatternTypes } from "../../app/oz/machine/patterns";
+
+describe("Matching values against patterns", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("has a matchers for all types", () => {
+    const includedTypes = Immutable.Set(Object.keys(matchers));
+    const types = Immutable.Set(allPatternTypes);
+
+    expect(includedTypes).toEqual(types);
+  });
+});

--- a/specs/pattern_match/number_spec.js
+++ b/specs/pattern_match/number_spec.js
@@ -1,0 +1,69 @@
+import Immutable from "immutable";
+import { literalExpression } from "../../app/oz/machine/expressions";
+import { literalNumber, literalAtom } from "../../app/oz/machine/literals";
+import { buildSigma, buildEnvironment } from "../../app/oz/machine/build";
+import { evaluate } from "../../app/oz/expression";
+import { patternMatch } from "../../app/oz/pattern_match";
+
+describe("Pattern matching against a number", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("matches when the numbers are the same", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalNumber(2)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalNumber(2);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(true);
+    expect(result.additionalBindings).toEqual(buildEnvironment());
+    expect(result.sigma).toEqual(sigma);
+  });
+
+  it("does not match when the numbers are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalNumber(2)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalNumber(10);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the types are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalAtom("person")),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalNumber(10);
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+});

--- a/specs/pattern_match/record_spec.js
+++ b/specs/pattern_match/record_spec.js
@@ -1,0 +1,236 @@
+import Immutable from "immutable";
+import { literalExpression } from "../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../app/oz/machine/lexical";
+import {
+  literalAtom,
+  literalNumber,
+  literalRecord,
+} from "../../app/oz/machine/literals";
+import {
+  valueAtom,
+  valueRecord,
+  valueNumber,
+} from "../../app/oz/machine/values";
+import {
+  buildSigma,
+  buildEquivalenceClass,
+  buildVariable,
+  buildEnvironment,
+  getLastAuxiliaryIdentifier,
+} from "../../app/oz/machine/build";
+import { evaluate } from "../../app/oz/expression";
+import { patternMatch } from "../../app/oz/pattern_match";
+
+describe("Pattern matching against a generic record", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("matches with no additional bindings when the records don't have any identifiers", () => {
+    const sigma = buildSigma(
+      buildEquivalenceClass(valueAtom("male"), buildVariable("g", 0)),
+    );
+    const environment = buildEnvironment({
+      G: buildVariable("g", 0),
+    });
+
+    const evaluation = evaluate(
+      literalExpression(
+        literalRecord("person", {
+          age: literalNumber(10),
+          gender: lexicalIdentifier("G"),
+        }),
+      ),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalRecord("person", {
+      age: literalNumber(10),
+      gender: literalAtom("male"),
+    });
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(true);
+    expect(result.additionalBindings).toEqual(buildEnvironment());
+    expect(result.sigma).toEqual(sigma);
+  });
+
+  it("matches with additional bindings when the records have identifiers", () => {
+    const sigma = buildSigma(
+      buildEquivalenceClass(valueAtom("male"), buildVariable("g", 0)),
+      buildEquivalenceClass(
+        valueRecord("address", {
+          number: valueNumber(172),
+          floor: buildVariable("f", 0),
+        }),
+        buildVariable("address", 0),
+      ),
+      buildEquivalenceClass(valueNumber(5), buildVariable("f", 0)),
+    );
+    const environment = buildEnvironment({
+      G: buildVariable("g", 0),
+      Address: buildVariable("address", 0),
+    });
+
+    const evaluation = evaluate(
+      literalExpression(
+        literalRecord("person", {
+          age: literalNumber(10),
+          gender: lexicalIdentifier("G"),
+          address: lexicalIdentifier("Address"),
+        }),
+      ),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalRecord("person", {
+      age: lexicalIdentifier("A"),
+      gender: literalAtom("male"),
+      address: literalRecord("address", {
+        number: literalNumber(172),
+        floor: lexicalIdentifier("F"),
+      }),
+    });
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(true);
+    expect(result.additionalBindings).toEqual(
+      buildEnvironment({
+        A: buildVariable(
+          getLastAuxiliaryIdentifier("patternMatch").get("identifier"),
+          0,
+        ),
+        F: buildVariable("f", 0),
+      }),
+    );
+    expect(result.sigma).toEqual(
+      buildSigma(
+        buildEquivalenceClass(valueAtom("male"), buildVariable("g", 0)),
+        buildEquivalenceClass(
+          valueRecord("address", {
+            number: valueNumber(172),
+            floor: buildVariable("f", 0),
+          }),
+          buildVariable("address", 0),
+        ),
+        buildEquivalenceClass(valueNumber(5), buildVariable("f", 0)),
+        buildEquivalenceClass(
+          valueNumber(10),
+          buildVariable(
+            getLastAuxiliaryIdentifier("patternMatch").get("identifier"),
+            0,
+          ),
+        ),
+      ),
+    );
+  });
+
+  it("does not match when the types are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(literalNumber(10)),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalRecord("person", { age: literalNumber(10) });
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the labels are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(
+        literalRecord("person", {
+          age: literalNumber(15),
+        }),
+      ),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalRecord("dog", { age: literalNumber(15) });
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when the features are different", () => {
+    const sigma = buildSigma();
+    const environment = buildEnvironment();
+
+    const evaluation = evaluate(
+      literalExpression(
+        literalRecord("person", {
+          age: literalNumber(15),
+        }),
+      ),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalRecord("person", { weight: literalNumber(15) });
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+
+  it("does not match when a nested literal is different", () => {
+    const sigma = buildSigma(
+      buildEquivalenceClass(
+        valueRecord("address", {
+          number: valueNumber(172),
+          floor: valueNumber(5),
+        }),
+        buildVariable("a", 0),
+      ),
+    );
+    const environment = buildEnvironment({
+      Address: buildVariable("a", 0),
+    });
+
+    const evaluation = evaluate(
+      literalExpression(
+        literalRecord("person", {
+          age: literalNumber(15),
+          address: lexicalIdentifier("Address"),
+        }),
+      ),
+      environment,
+      sigma,
+    );
+
+    const pattern = literalRecord("person", {
+      age: literalNumber(15),
+      address: literalRecord("address", {
+        number: lexicalIdentifier("N"),
+        floor: literalNumber(10),
+      }),
+    });
+
+    const result = patternMatch(evaluation, pattern, sigma);
+
+    expect(result.match).toEqual(false);
+    expect(result.additionalBindings).toEqual(undefined);
+    expect(result.sigma).toEqual(undefined);
+  });
+});


### PR DESCRIPTION
## Summary of changes

* Fixes pattern matching parsing by separating parsing from literals. This will be especially important when we implement nested expressions on literals, as patterns don't support nested expressions, but do support nested identifiers.
* Fixes pattern match execution. Splits the match logic itself from the pattern matching statement, and adds a bunch of tests to the match logic.

## Related issues

* Closes kozily/admin#158