### PR TITLE
167 - Fixes broken collect free identifiers on records

### DIFF
--- a/app/oz/free_identifiers/literals/record.js
+++ b/app/oz/free_identifiers/literals/record.js
@@ -6,7 +6,7 @@ export default (recurse, literal) => {
     .valueSeq()
     .flatMap(feature => {
       if (feature.get("node") === "identifier") {
-        return Immutable.Set(feature.get("identifier"));
+        return Immutable.Set.of(feature.get("identifier"));
       }
 
       return recurse(feature);

--- a/specs/free_identifiers/literals/record_spec.js
+++ b/specs/free_identifiers/literals/record_spec.js
@@ -28,4 +28,12 @@ describe("Collecting free identifiers in a record literal", () => {
 
     expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set(["A", "N"]));
   });
+
+  it("collects nested identifiers when the identifier has more than one letter", () => {
+    const literal = literalRecord("person", {
+      age: lexicalIdentifier("Age"),
+    });
+
+    expect(collectFreeIdentifiers(literal)).toEqual(Immutable.Set.of("Age"));
+  });
 });

--- a/specs/parser/literals/record_spec.js
+++ b/specs/parser/literals/record_spec.js
@@ -73,4 +73,12 @@ describe("Parsing record literals", () => {
       }),
     );
   });
+
+  it("handles literals with identifiers having multiple letters", () => {
+    expect(parse("person(age:Age)")).toEqual(
+      literalRecord("person", {
+        age: lexicalIdentifier("Age"),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary of changes

* When the identifier contains more than one character, `Immutable.Set(identifier)` iterates over it's argument, creating a set with one identifier per letter of the original identifier argument. `Immutable.Set.of(identifier)` instead creates a set with a single identifier instead.

## Related issues

* Closes kozily/admin#167