### PR TITLE
166 - Statements as expressions

### DIFF
--- a/app/oz/compilation/expressions/conditional.js
+++ b/app/oz/compilation/expressions/conditional.js
@@ -1,0 +1,82 @@
+import { identifierExpression } from "../../machine/expressions";
+import { makeAuxiliaryIdentifier } from "../../machine/build";
+import {
+  localStatement,
+  bindingStatement,
+  sequenceStatement,
+  conditionalStatement,
+  skipStatement,
+} from "../../machine/statements";
+
+const compileStatementAndExpression = (
+  recurse,
+  statement,
+  expression,
+  resultingExpression,
+) => {
+  const compiledExpression = recurse(expression, resultingExpression);
+
+  const binding = compiledExpression.augmentStatement(
+    bindingStatement(
+      resultingExpression,
+      compiledExpression.resultingExpression,
+    ),
+  );
+  return statement ? sequenceStatement(recurse(statement), binding) : binding;
+};
+
+export default (recurse, node, resultingIdentifier) => {
+  const auxiliaryIdentifier = makeAuxiliaryIdentifier("exp");
+
+  const resultingExpression = resultingIdentifier
+    ? resultingIdentifier
+    : identifierExpression(auxiliaryIdentifier);
+
+  const trueStatement = node.getIn(["trueClause", "statement"]);
+  const trueExpression = node.getIn(["trueClause", "expression"]);
+
+  const compiledTrueStatement = compileStatementAndExpression(
+    recurse,
+    trueStatement,
+    trueExpression,
+    resultingExpression,
+  );
+
+  const falseStatement = node.getIn(["falseClause", "statement"]);
+  const falseExpression = node.getIn(["falseClause", "expression"]);
+
+  const compiledFalseStatement = falseExpression
+    ? compileStatementAndExpression(
+        recurse,
+        falseStatement,
+        falseExpression,
+        resultingExpression,
+      )
+    : skipStatement();
+
+  const compiledCondition = recurse(node.get("condition"));
+
+  const resultingStatement = compiledCondition.augmentStatement(
+    conditionalStatement(
+      compiledCondition.resultingExpression,
+      compiledTrueStatement,
+      compiledFalseStatement,
+    ),
+  );
+
+  const augmentStatement = statement => {
+    if (resultingIdentifier) {
+      return resultingStatement;
+    }
+
+    return localStatement(
+      auxiliaryIdentifier,
+      sequenceStatement(resultingStatement, statement),
+    );
+  };
+
+  return {
+    resultingExpression,
+    augmentStatement,
+  };
+};

--- a/app/oz/compilation/expressions/exception_context.js
+++ b/app/oz/compilation/expressions/exception_context.js
@@ -1,0 +1,78 @@
+import { identifierExpression } from "../../machine/expressions";
+import { makeAuxiliaryIdentifier } from "../../machine/build";
+import {
+  localStatement,
+  bindingStatement,
+  sequenceStatement,
+  exceptionContextStatement,
+  skipStatement,
+} from "../../machine/statements";
+
+const compileStatementAndExpression = (
+  recurse,
+  statement,
+  expression,
+  resultingExpression,
+) => {
+  const compiledExpression = recurse(expression, resultingExpression);
+
+  const binding = compiledExpression.augmentStatement(
+    bindingStatement(
+      resultingExpression,
+      compiledExpression.resultingExpression,
+    ),
+  );
+  return statement ? sequenceStatement(recurse(statement), binding) : binding;
+};
+
+export default (recurse, node, resultingIdentifier) => {
+  const auxiliaryIdentifier = makeAuxiliaryIdentifier("exp");
+
+  const resultingExpression = resultingIdentifier
+    ? resultingIdentifier
+    : identifierExpression(auxiliaryIdentifier);
+
+  const tryStatement = node.getIn(["tryClause", "statement"]);
+  const tryExpression = node.getIn(["tryClause", "expression"]);
+
+  const compiledTryStatement = compileStatementAndExpression(
+    recurse,
+    tryStatement,
+    tryExpression,
+    resultingExpression,
+  );
+
+  const exceptionStatement = node.getIn(["exceptionClause", "statement"]);
+  const exceptionExpression = node.getIn(["exceptionClause", "expression"]);
+
+  const compiledExceptionStatement = exceptionExpression
+    ? compileStatementAndExpression(
+        recurse,
+        exceptionStatement,
+        exceptionExpression,
+        resultingExpression,
+      )
+    : skipStatement();
+
+  const resultingStatement = exceptionContextStatement(
+    compiledTryStatement,
+    node.get("exceptionIdentifier"),
+    compiledExceptionStatement,
+  );
+
+  const augmentStatement = statement => {
+    if (resultingIdentifier) {
+      return resultingStatement;
+    }
+
+    return localStatement(
+      auxiliaryIdentifier,
+      sequenceStatement(resultingStatement, statement),
+    );
+  };
+
+  return {
+    resultingExpression,
+    augmentStatement,
+  };
+};

--- a/app/oz/compilation/expressions/local.js
+++ b/app/oz/compilation/expressions/local.js
@@ -13,7 +13,10 @@ export default (recurse, node, resultingIdentifier) => {
     ? resultingIdentifier
     : identifierExpression(auxiliaryIdentifier);
 
-  const compiledExpression = recurse(node.get("expression"));
+  const compiledExpression = recurse(
+    node.get("expression"),
+    resultingIdentifier,
+  );
 
   const finalBinding = compiledExpression.augmentStatement(
     bindingStatement(

--- a/app/oz/compilation/expressions/local.js
+++ b/app/oz/compilation/expressions/local.js
@@ -1,0 +1,51 @@
+import { identifierExpression } from "../../machine/expressions";
+import { makeAuxiliaryIdentifier } from "../../machine/build";
+import {
+  localStatement,
+  bindingStatement,
+  sequenceStatement,
+} from "../../machine/statements";
+
+export default (recurse, node, resultingIdentifier) => {
+  const auxiliaryIdentifier = makeAuxiliaryIdentifier("exp");
+
+  const resultingExpression = resultingIdentifier
+    ? resultingIdentifier
+    : identifierExpression(auxiliaryIdentifier);
+
+  const compiledExpression = recurse(node.get("expression"));
+
+  const finalBinding = compiledExpression.augmentStatement(
+    bindingStatement(
+      resultingExpression,
+      compiledExpression.resultingExpression,
+    ),
+  );
+
+  const childStatement = node.get("statement")
+    ? sequenceStatement(recurse(node.get("statement")), finalBinding)
+    : finalBinding;
+
+  const resultingStatement = node
+    .get("identifiers")
+    .reduceRight(
+      (child, identifier) => localStatement(identifier, child),
+      childStatement,
+    );
+
+  const augmentStatement = statement => {
+    if (resultingIdentifier) {
+      return resultingStatement;
+    }
+
+    return localStatement(
+      auxiliaryIdentifier,
+      sequenceStatement(resultingStatement, statement),
+    );
+  };
+
+  return {
+    resultingExpression,
+    augmentStatement,
+  };
+};

--- a/app/oz/compilation/expressions/pattern_matching.js
+++ b/app/oz/compilation/expressions/pattern_matching.js
@@ -1,0 +1,85 @@
+import { identifierExpression } from "../../machine/expressions";
+import { makeAuxiliaryIdentifier } from "../../machine/build";
+import {
+  localStatement,
+  bindingStatement,
+  sequenceStatement,
+  patternMatchingStatement,
+  skipStatement,
+} from "../../machine/statements";
+
+const compileStatementAndExpression = (
+  recurse,
+  statement,
+  expression,
+  resultingExpression,
+) => {
+  const compiledExpression = recurse(expression, resultingExpression);
+
+  const binding = compiledExpression.augmentStatement(
+    bindingStatement(
+      resultingExpression,
+      compiledExpression.resultingExpression,
+    ),
+  );
+  return statement ? sequenceStatement(recurse(statement), binding) : binding;
+};
+
+export default (recurse, node, resultingIdentifier) => {
+  const auxiliaryIdentifier = makeAuxiliaryIdentifier("exp");
+
+  const resultingExpression = resultingIdentifier
+    ? resultingIdentifier
+    : identifierExpression(auxiliaryIdentifier);
+
+  const falseStatement = node.getIn(["falseClause", "statement"]);
+  const falseExpression = node.getIn(["falseClause", "expression"]);
+
+  const compiledFinalFalseStatement = falseExpression
+    ? compileStatementAndExpression(
+        recurse,
+        falseStatement,
+        falseExpression,
+        resultingExpression,
+      )
+    : skipStatement();
+
+  const expressionCompilation = recurse(node.get("identifier"));
+
+  const rawResultingStatement = node
+    .get("clauses")
+    .reduceRight((result, clause) => {
+      const compiledClause = compileStatementAndExpression(
+        recurse,
+        clause.get("statement"),
+        clause.get("expression"),
+        resultingExpression,
+      );
+      return patternMatchingStatement(
+        expressionCompilation.resultingExpression,
+        clause.get("pattern"),
+        compiledClause,
+        result,
+      );
+    }, compiledFinalFalseStatement);
+
+  const resultingStatement = expressionCompilation.augmentStatement(
+    rawResultingStatement,
+  );
+
+  const augmentStatement = statement => {
+    if (resultingIdentifier) {
+      return resultingStatement;
+    }
+
+    return localStatement(
+      auxiliaryIdentifier,
+      sequenceStatement(resultingStatement, statement),
+    );
+  };
+
+  return {
+    resultingExpression,
+    augmentStatement,
+  };
+};

--- a/app/oz/compilation/index.js
+++ b/app/oz/compilation/index.js
@@ -33,6 +33,7 @@ import operatorExpression from "./expressions/operator";
 import functionExpression from "./expressions/function";
 import localExpression from "./expressions/local";
 import conditionalExpression from "./expressions/conditional";
+import patternMatchingExpression from "./expressions/pattern_matching";
 import exceptionContextExpression from "./expressions/exception_context";
 
 export const compilers = {
@@ -68,6 +69,7 @@ export const compilers = {
     [compilableExpressionTypes.local]: localExpression,
     [compilableExpressionTypes.conditional]: conditionalExpression,
     [compilableExpressionTypes.exceptionContext]: exceptionContextExpression,
+    [compilableExpressionTypes.patternMatching]: patternMatchingExpression,
   },
 };
 

--- a/app/oz/compilation/index.js
+++ b/app/oz/compilation/index.js
@@ -32,6 +32,7 @@ import identifierExpression from "./expressions/identifier";
 import operatorExpression from "./expressions/operator";
 import functionExpression from "./expressions/function";
 import localExpression from "./expressions/local";
+import conditionalExpression from "./expressions/conditional";
 
 export const compilers = {
   statement: {
@@ -64,6 +65,7 @@ export const compilers = {
     [kernelExpressionTypes.operator]: operatorExpression,
     [compilableExpressionTypes.function]: functionExpression,
     [compilableExpressionTypes.local]: localExpression,
+    [compilableExpressionTypes.conditional]: conditionalExpression,
   },
 };
 

--- a/app/oz/compilation/index.js
+++ b/app/oz/compilation/index.js
@@ -33,6 +33,7 @@ import operatorExpression from "./expressions/operator";
 import functionExpression from "./expressions/function";
 import localExpression from "./expressions/local";
 import conditionalExpression from "./expressions/conditional";
+import exceptionContextExpression from "./expressions/exception_context";
 
 export const compilers = {
   statement: {
@@ -66,6 +67,7 @@ export const compilers = {
     [compilableExpressionTypes.function]: functionExpression,
     [compilableExpressionTypes.local]: localExpression,
     [compilableExpressionTypes.conditional]: conditionalExpression,
+    [compilableExpressionTypes.exceptionContext]: exceptionContextExpression,
   },
 };
 

--- a/app/oz/compilation/index.js
+++ b/app/oz/compilation/index.js
@@ -31,6 +31,7 @@ import literalExpression from "./expressions/literal";
 import identifierExpression from "./expressions/identifier";
 import operatorExpression from "./expressions/operator";
 import functionExpression from "./expressions/function";
+import localExpression from "./expressions/local";
 
 export const compilers = {
   statement: {
@@ -62,6 +63,7 @@ export const compilers = {
     [kernelExpressionTypes.identifier]: identifierExpression,
     [kernelExpressionTypes.operator]: operatorExpression,
     [compilableExpressionTypes.function]: functionExpression,
+    [compilableExpressionTypes.local]: localExpression,
   },
 };
 

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -431,6 +431,7 @@ exp_terminal ->
   | exp_terminal_literal {% id %}
   | exp_terminal_paren {% id %}
   | exp_terminal_function {% id %}
+  | exp_terminal_local {% id %}
 
 exp_terminal_identifier -> ids_identifier {% expBuildExpressionWrapper(0, "identifier") %}
 
@@ -446,6 +447,21 @@ exp_terminal_function -> "{" _ exp_expression (__ exp_expression):* _ "}" {%
     });
 
     return expBuildFunctionExpression(functionExpression, functionArguments);
+  }
+%}
+
+exp_terminal_local -> "local" __ stm_local_identifier_list __ "in" __ (stm_sequence __):? exp_expression __ "end" {%
+  function(d) {
+    var identifiers = d[2];
+    var statement = d[6] ? d[6][0] : undefined;
+    var expression = d[7];
+    return {
+      node: "expression",
+      type: "local",
+      identifiers: identifiers,
+      statement: statement,
+      expression: expression,
+    };
   }
 %}
 

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -433,6 +433,7 @@ exp_terminal ->
   | exp_terminal_function {% id %}
   | exp_terminal_local {% id %}
   | exp_terminal_conditional {% id %}
+  | exp_terminal_try {% id %}
 
 exp_terminal_identifier -> ids_identifier {% expBuildExpressionWrapper(0, "identifier") %}
 
@@ -485,6 +486,28 @@ exp_terminal_conditional -> "if" __ exp_expression __ "then" __ (stm_sequence __
       trueClause: trueClause,
       falseClause: falseClause,
     }
+  }
+%}
+
+exp_terminal_try -> "try" __ (stm_sequence __):? exp_expression __ "catch" __ ids_identifier __ "then" __ (stm_sequence __):? exp_expression __ "end" {%
+  function(d) {
+    var tryClause = {
+      statement: d[2] ? d[2][0] : undefined,
+      expression: d[3],
+    };
+    var exceptionIdentifier = d[7];
+    var exceptionClause = {
+      statement: d[11] ? d[11][0] : undefined,
+      expression: d[12],
+    };
+
+    return {
+      node: "expression",
+      type: "exceptionContext",
+      tryClause: tryClause,
+      exceptionClause: exceptionClause,
+      exceptionIdentifier: exceptionIdentifier,
+    };
   }
 %}
 

--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -432,6 +432,7 @@ exp_terminal ->
   | exp_terminal_paren {% id %}
   | exp_terminal_function {% id %}
   | exp_terminal_local {% id %}
+  | exp_terminal_conditional {% id %}
 
 exp_terminal_identifier -> ids_identifier {% expBuildExpressionWrapper(0, "identifier") %}
 
@@ -462,6 +463,28 @@ exp_terminal_local -> "local" __ stm_local_identifier_list __ "in" __ (stm_seque
       statement: statement,
       expression: expression,
     };
+  }
+%}
+
+exp_terminal_conditional -> "if" __ exp_expression __ "then" __ (stm_sequence __):? exp_expression __ ("else" __ (stm_sequence __):? exp_expression __):? "end" {%
+  function(d, position, reject) {
+    var condition = d[2];
+    var trueClause = {
+      statement: d[6] ? d[6][0]: undefined,
+      expression: d[7],
+    };
+
+    var falseClause = d[9]
+      ? { statement: d[9][2] ? d[9][2][0] : undefined, expression: d[9][3] }
+      : undefined;
+
+    return {
+      node: "expression",
+      type: "conditional",
+      condition: condition,
+      trueClause: trueClause,
+      falseClause: falseClause,
+    }
   }
 %}
 

--- a/app/oz/machine/build.js
+++ b/app/oz/machine/build.js
@@ -219,3 +219,7 @@ export const makeAuxiliaryIdentifier = (namespace = "") => {
 export const getLastAuxiliaryIdentifier = (namespace = "", ago = 1) => {
   return lexicalIdentifier(`@${namespace}${argumentIndex - ago}`);
 };
+
+export const resetAuxiliaryIdentifierIndex = () => {
+  argumentIndex = 0;
+};

--- a/app/oz/machine/expressions.js
+++ b/app/oz/machine/expressions.js
@@ -8,6 +8,7 @@ export const kernelExpressionTypes = {
 
 export const compilableExpressionTypes = {
   function: "function",
+  local: "local",
 };
 
 export const literalExpression = literal => {
@@ -42,6 +43,16 @@ export const functionExpression = (fun, args = []) => {
     type: compilableExpressionTypes.function,
     fun,
     args,
+  });
+};
+
+export const localExpression = (identifiers, expression, statement) => {
+  return Immutable.fromJS({
+    node: "expression",
+    type: compilableExpressionTypes.local,
+    identifiers,
+    expression,
+    statement,
   });
 };
 

--- a/app/oz/machine/expressions.js
+++ b/app/oz/machine/expressions.js
@@ -10,6 +10,7 @@ export const compilableExpressionTypes = {
   function: "function",
   local: "local",
   conditional: "conditional",
+  exceptionContext: "exceptionContext",
 };
 
 export const literalExpression = literal => {
@@ -64,6 +65,20 @@ export const conditionalExpression = (condition, trueClause, falseClause) => {
     condition,
     trueClause,
     falseClause,
+  });
+};
+
+export const exceptionContextExpression = (
+  tryClause,
+  exceptionClause,
+  exceptionIdentifier,
+) => {
+  return Immutable.fromJS({
+    node: "expression",
+    type: compilableExpressionTypes.exceptionContext,
+    tryClause,
+    exceptionClause,
+    exceptionIdentifier,
   });
 };
 

--- a/app/oz/machine/expressions.js
+++ b/app/oz/machine/expressions.js
@@ -9,6 +9,7 @@ export const kernelExpressionTypes = {
 export const compilableExpressionTypes = {
   function: "function",
   local: "local",
+  conditional: "conditional",
 };
 
 export const literalExpression = literal => {
@@ -53,6 +54,16 @@ export const localExpression = (identifiers, expression, statement) => {
     identifiers,
     expression,
     statement,
+  });
+};
+
+export const conditionalExpression = (condition, trueClause, falseClause) => {
+  return Immutable.fromJS({
+    node: "expression",
+    type: compilableExpressionTypes.conditional,
+    condition,
+    trueClause,
+    falseClause,
   });
 };
 

--- a/app/oz/machine/expressions.js
+++ b/app/oz/machine/expressions.js
@@ -11,6 +11,7 @@ export const compilableExpressionTypes = {
   local: "local",
   conditional: "conditional",
   exceptionContext: "exceptionContext",
+  patternMatching: "patternMatching",
 };
 
 export const literalExpression = literal => {
@@ -79,6 +80,16 @@ export const exceptionContextExpression = (
     tryClause,
     exceptionClause,
     exceptionIdentifier,
+  });
+};
+
+export const patternMatchingExpression = (identifier, clauses, falseClause) => {
+  return Immutable.fromJS({
+    node: "expression",
+    type: compilableExpressionTypes.patternMatching,
+    identifier,
+    clauses,
+    falseClause,
   });
 };
 

--- a/app/oz/print/identifier.js
+++ b/app/oz/print/identifier.js
@@ -1,4 +1,8 @@
 export default identifier => {
+  if (identifier === "_") {
+    return identifier;
+  }
+
   const unquotedRegex = /^[A-Z][a-zA-Z0-9]*$/;
   if (unquotedRegex.test(identifier)) {
     return identifier;

--- a/app/state/parse.js
+++ b/app/state/parse.js
@@ -2,7 +2,10 @@ import Immutable from "immutable";
 import parser from "../oz/parser";
 import { compile } from "../oz/compilation";
 import { collectFreeIdentifiers } from "../oz/free_identifiers";
-import { defaultEnvironment } from "../oz/machine/build";
+import {
+  defaultEnvironment,
+  resetAuxiliaryIdentifierIndex,
+} from "../oz/machine/build";
 
 const defaultIdentifiers = Immutable.Set(defaultEnvironment().keySeq());
 
@@ -23,6 +26,7 @@ export const reducer = (previousState = initialState, action) => {
   switch (action.type) {
     case "CHANGE_SOURCE_CODE": {
       try {
+        resetAuxiliaryIdentifierIndex();
         const ast = parser(action.payload);
         const compilation = compile(ast);
         const freeIdentifiers = collectFreeIdentifiers(compilation).subtract(

--- a/app/state/runtime.js
+++ b/app/state/runtime.js
@@ -1,7 +1,11 @@
 import Immutable from "immutable";
 import parser from "../oz/parser";
 import { compile } from "../oz/compilation";
-import { buildState, buildFromKernelAST } from "../oz/machine/build";
+import {
+  buildState,
+  buildFromKernelAST,
+  resetAuxiliaryIdentifierIndex,
+} from "../oz/machine/build";
 import { executeSingleStep } from "../oz/runtime";
 import { resetEnvironmentIndex } from "../oz/machine/environment";
 
@@ -47,9 +51,10 @@ export const toggleShowSystemVariables = () => {
 export const reducer = (previousState = initialState, action) => {
   switch (action.type) {
     case "RUNTIME_RUN": {
+      resetAuxiliaryIdentifierIndex();
+      resetEnvironmentIndex();
       const ast = parser(previousState.get("source"));
       const kernel = compile(ast);
-      resetEnvironmentIndex();
       const runtime = buildFromKernelAST(kernel);
       return previousState
         .set("steps", Immutable.List.of(runtime))

--- a/specs/compilation/expressions/conditional_spec.js
+++ b/specs/compilation/expressions/conditional_spec.js
@@ -1,0 +1,249 @@
+import Immutable from "immutable";
+import { compile } from "../../../app/oz/compilation";
+import {
+  conditionalExpression,
+  literalExpression,
+} from "../../../app/oz/machine/expressions";
+import {
+  skipStatementSyntax,
+  sequenceStatementSyntax,
+} from "../../../app/oz/machine/statementSyntax";
+import {
+  skipStatement,
+  localStatement,
+  sequenceStatement,
+  bindingStatement,
+  conditionalStatement,
+} from "../../../app/oz/machine/statements";
+import { literalNumber } from "../../../app/oz/machine/literals";
+import { identifier, auxExpression, auxExpressionIdentifier } from "../helpers";
+
+describe("Compiling conditional statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  describe("when not providing a resulting identifier", () => {
+    it("compiles if the expression has both true clause and false clause", () => {
+      const expression = conditionalExpression(
+        identifier("X"),
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            conditionalStatement(
+              identifier("X"),
+              sequenceStatement(
+                skipStatement(),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(5)),
+                ),
+              ),
+              sequenceStatement(
+                sequenceStatement(skipStatement(), skipStatement()),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(10)),
+                ),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the expression has both true clause and false clause but no statements", () => {
+      const expression = conditionalExpression(
+        identifier("X"),
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            conditionalStatement(
+              identifier("X"),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(5)),
+              ),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(10)),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the expression has only true clause", () => {
+      const expression = conditionalExpression(identifier("X"), {
+        statement: undefined,
+        expression: literalExpression(literalNumber(5)),
+      });
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            conditionalStatement(
+              identifier("X"),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(5)),
+              ),
+              skipStatement(),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+  });
+
+  describe("when providing a resulting identifier", () => {
+    it("compiles if the expression has both true clause and false clause", () => {
+      const expression = conditionalExpression(
+        identifier("X"),
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        conditionalStatement(
+          identifier("X"),
+          sequenceStatement(
+            skipStatement(),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(5)),
+            ),
+          ),
+          sequenceStatement(
+            sequenceStatement(skipStatement(), skipStatement()),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(10)),
+            ),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the expression has both true clause and false clause but no statements", () => {
+      const expression = conditionalExpression(
+        identifier("X"),
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        conditionalStatement(
+          identifier("X"),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(5)),
+          ),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(10)),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the expression has only true clause", () => {
+      const expression = conditionalExpression(identifier("X"), {
+        statement: undefined,
+        expression: literalExpression(literalNumber(5)),
+      });
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        conditionalStatement(
+          identifier("X"),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(5)),
+          ),
+          skipStatement(),
+        ),
+      );
+    });
+  });
+});

--- a/specs/compilation/expressions/exception_context_spec.js
+++ b/specs/compilation/expressions/exception_context_spec.js
@@ -1,0 +1,196 @@
+import Immutable from "immutable";
+import { compile } from "../../../app/oz/compilation";
+import {
+  exceptionContextExpression,
+  literalExpression,
+} from "../../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import {
+  skipStatementSyntax,
+  sequenceStatementSyntax,
+} from "../../../app/oz/machine/statementSyntax";
+import {
+  skipStatement,
+  localStatement,
+  sequenceStatement,
+  bindingStatement,
+  exceptionContextStatement,
+} from "../../../app/oz/machine/statements";
+import { literalNumber } from "../../../app/oz/machine/literals";
+import { identifier, auxExpression, auxExpressionIdentifier } from "../helpers";
+
+describe("Compiling exception context statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  describe("when not providing a resulting identifier", () => {
+    it("compiles if the exception context statement has statements", () => {
+      const expression = exceptionContextExpression(
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(10)),
+        },
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(20)),
+        },
+        lexicalIdentifier("Error"),
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            exceptionContextStatement(
+              sequenceStatement(
+                skipStatement(),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(10)),
+                ),
+              ),
+              lexicalIdentifier("Error"),
+              sequenceStatement(
+                sequenceStatement(skipStatement(), skipStatement()),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(20)),
+                ),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the exception context statement doesn't have statements", () => {
+      const expression = exceptionContextExpression(
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(20)),
+        },
+        lexicalIdentifier("Error"),
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            exceptionContextStatement(
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(10)),
+              ),
+              lexicalIdentifier("Error"),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(20)),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+  });
+
+  describe("when providing a resulting identifier", () => {
+    it("compiles if the local statement has statements", () => {
+      const expression = exceptionContextExpression(
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(10)),
+        },
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(20)),
+        },
+        lexicalIdentifier("Error"),
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        exceptionContextStatement(
+          sequenceStatement(
+            skipStatement(),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(10)),
+            ),
+          ),
+          lexicalIdentifier("Error"),
+          sequenceStatement(
+            sequenceStatement(skipStatement(), skipStatement()),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(20)),
+            ),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the local statement doesn't have statements", () => {
+      const expression = exceptionContextExpression(
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(20)),
+        },
+        lexicalIdentifier("Error"),
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        exceptionContextStatement(
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(10)),
+          ),
+          lexicalIdentifier("Error"),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(20)),
+          ),
+        ),
+      );
+    });
+  });
+});

--- a/specs/compilation/expressions/local_spec.js
+++ b/specs/compilation/expressions/local_spec.js
@@ -1,0 +1,92 @@
+import Immutable from "immutable";
+import { compile } from "../../../app/oz/compilation";
+import {
+  localExpression,
+  literalExpression,
+} from "../../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import { skipStatementSyntax } from "../../../app/oz/machine/statementSyntax";
+import {
+  skipStatement,
+  localStatement,
+  sequenceStatement,
+  bindingStatement,
+} from "../../../app/oz/machine/statements";
+import { literalNumber } from "../../../app/oz/machine/literals";
+import { identifier, auxExpression, auxExpressionIdentifier } from "../helpers";
+
+describe("Compiling local statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  describe("when not providing a resulting identifier", () => {
+    it("compiles", () => {
+      const expression = localExpression(
+        [lexicalIdentifier("X"), lexicalIdentifier("Y")],
+        literalExpression(literalNumber(10)),
+        skipStatementSyntax(),
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            localStatement(
+              lexicalIdentifier("X"),
+              localStatement(
+                lexicalIdentifier("Y"),
+                sequenceStatement(
+                  skipStatement(),
+                  bindingStatement(
+                    auxExpression(),
+                    literalExpression(literalNumber(10)),
+                  ),
+                ),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+  });
+
+  describe("when providing a resulting identifier", () => {
+    it("compiles", () => {
+      const expression = localExpression(
+        [lexicalIdentifier("X"), lexicalIdentifier("Y")],
+        literalExpression(literalNumber(10)),
+        skipStatementSyntax(),
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          lexicalIdentifier("X"),
+          localStatement(
+            lexicalIdentifier("Y"),
+            sequenceStatement(
+              skipStatement(),
+              bindingStatement(
+                identifier("R"),
+                literalExpression(literalNumber(10)),
+              ),
+            ),
+          ),
+        ),
+      );
+    });
+  });
+});

--- a/specs/compilation/expressions/local_spec.js
+++ b/specs/compilation/expressions/local_spec.js
@@ -21,7 +21,7 @@ describe("Compiling local statement expressions", () => {
   });
 
   describe("when not providing a resulting identifier", () => {
-    it("compiles", () => {
+    it("compiles if the local statement has statements", () => {
       const expression = localExpression(
         [lexicalIdentifier("X"), lexicalIdentifier("Y")],
         literalExpression(literalNumber(10)),
@@ -56,10 +56,42 @@ describe("Compiling local statement expressions", () => {
         ),
       );
     });
+
+    it("compiles if the local statement doesn't have statements", () => {
+      const expression = localExpression(
+        [lexicalIdentifier("X"), lexicalIdentifier("Y")],
+        literalExpression(literalNumber(10)),
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            localStatement(
+              lexicalIdentifier("X"),
+              localStatement(
+                lexicalIdentifier("Y"),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(10)),
+                ),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
   });
 
   describe("when providing a resulting identifier", () => {
-    it("compiles", () => {
+    it("compiles if the local statement has statements", () => {
       const expression = localExpression(
         [lexicalIdentifier("X"), lexicalIdentifier("Y")],
         literalExpression(literalNumber(10)),
@@ -83,6 +115,32 @@ describe("Compiling local statement expressions", () => {
                 identifier("R"),
                 literalExpression(literalNumber(10)),
               ),
+            ),
+          ),
+        ),
+      );
+    });
+
+    it("compiles if the local statement doesn't have statements", () => {
+      const expression = localExpression(
+        [lexicalIdentifier("X"), lexicalIdentifier("Y")],
+        literalExpression(literalNumber(10)),
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+
+      expect(resultingStatement).toEqual(
+        localStatement(
+          lexicalIdentifier("X"),
+          localStatement(
+            lexicalIdentifier("Y"),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(10)),
             ),
           ),
         ),

--- a/specs/compilation/expressions/pattern_matching_spec.js
+++ b/specs/compilation/expressions/pattern_matching_spec.js
@@ -1,0 +1,353 @@
+import Immutable from "immutable";
+import { compile } from "../../../app/oz/compilation";
+import {
+  patternMatchingExpression,
+  literalExpression,
+} from "../../../app/oz/machine/expressions";
+import {
+  skipStatementSyntax,
+  sequenceStatementSyntax,
+} from "../../../app/oz/machine/statementSyntax";
+import {
+  skipStatement,
+  localStatement,
+  sequenceStatement,
+  bindingStatement,
+  patternMatchingStatement,
+} from "../../../app/oz/machine/statements";
+import { literalNumber, literalRecord } from "../../../app/oz/machine/literals";
+import { identifier, auxExpression, auxExpressionIdentifier } from "../helpers";
+
+describe("Compiling pattern matching statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  describe("when not providing a resulting identifier", () => {
+    it("compiles a single clause with else clause having both statements and expressions", () => {
+      const expression = patternMatchingExpression(
+        identifier("X"),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: skipStatementSyntax(),
+            expression: literalExpression(literalNumber(5)),
+          },
+        ],
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            patternMatchingStatement(
+              identifier("X"),
+              literalRecord("person"),
+              sequenceStatement(
+                skipStatement(),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(5)),
+                ),
+              ),
+              sequenceStatement(
+                sequenceStatement(skipStatement(), skipStatement()),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(10)),
+                ),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+
+    it("compiles a single clause with else clause having expressions", () => {
+      const expression = patternMatchingExpression(
+        identifier("X"),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: undefined,
+            expression: literalExpression(literalNumber(5)),
+          },
+        ],
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            patternMatchingStatement(
+              identifier("X"),
+              literalRecord("person"),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(5)),
+              ),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(10)),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+
+    it("compiles a single clause without else clause having expressions", () => {
+      const expression = patternMatchingExpression(identifier("X"), [
+        {
+          pattern: literalRecord("person"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+      ]);
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            patternMatchingStatement(
+              identifier("X"),
+              literalRecord("person"),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(5)),
+              ),
+              skipStatement(),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+
+    it("compiles multiple clauses without else clause having expressions", () => {
+      const expression = patternMatchingExpression(identifier("X"), [
+        {
+          pattern: literalRecord("person"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          pattern: literalRecord("animal"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      ]);
+
+      const compilation = compile(expression);
+
+      expect(compilation.resultingExpression).toEqual(auxExpression());
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        localStatement(
+          auxExpressionIdentifier(),
+          sequenceStatement(
+            patternMatchingStatement(
+              identifier("X"),
+              literalRecord("person"),
+              bindingStatement(
+                auxExpression(),
+                literalExpression(literalNumber(5)),
+              ),
+              patternMatchingStatement(
+                identifier("X"),
+                literalRecord("animal"),
+                bindingStatement(
+                  auxExpression(),
+                  literalExpression(literalNumber(10)),
+                ),
+                skipStatement(),
+              ),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+  });
+
+  describe("when providing a resulting identifier", () => {
+    it("compiles a single clause with else clause having both statements and expressions", () => {
+      const expression = patternMatchingExpression(
+        identifier("X"),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: skipStatementSyntax(),
+            expression: literalExpression(literalNumber(5)),
+          },
+        ],
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        patternMatchingStatement(
+          identifier("X"),
+          literalRecord("person"),
+          sequenceStatement(
+            skipStatement(),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(5)),
+            ),
+          ),
+          sequenceStatement(
+            sequenceStatement(skipStatement(), skipStatement()),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(10)),
+            ),
+          ),
+        ),
+      );
+    });
+
+    it("compiles a single clause with else clause having expressions", () => {
+      const expression = patternMatchingExpression(
+        identifier("X"),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: undefined,
+            expression: literalExpression(literalNumber(5)),
+          },
+        ],
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      );
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        patternMatchingStatement(
+          identifier("X"),
+          literalRecord("person"),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(5)),
+          ),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(10)),
+          ),
+        ),
+      );
+    });
+
+    it("compiles a single clause without else clause having expressions", () => {
+      const expression = patternMatchingExpression(identifier("X"), [
+        {
+          pattern: literalRecord("person"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+      ]);
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        patternMatchingStatement(
+          identifier("X"),
+          literalRecord("person"),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(5)),
+          ),
+          skipStatement(),
+        ),
+      );
+    });
+
+    it("compiles multiple clauses without else clause having expressions", () => {
+      const expression = patternMatchingExpression(identifier("X"), [
+        {
+          pattern: literalRecord("person"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          pattern: literalRecord("animal"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      ]);
+
+      const compilation = compile(expression, identifier("R"));
+
+      expect(compilation.resultingExpression).toEqual(identifier("R"));
+
+      const resultingStatement = compilation.augmentStatement(skipStatement());
+      expect(resultingStatement).toEqual(
+        patternMatchingStatement(
+          identifier("X"),
+          literalRecord("person"),
+          bindingStatement(
+            identifier("R"),
+            literalExpression(literalNumber(5)),
+          ),
+          patternMatchingStatement(
+            identifier("X"),
+            literalRecord("animal"),
+            bindingStatement(
+              identifier("R"),
+              literalExpression(literalNumber(10)),
+            ),
+            skipStatement(),
+          ),
+        ),
+      );
+    });
+  });
+});

--- a/specs/parser/expressions/conditional_spec.js
+++ b/specs/parser/expressions/conditional_spec.js
@@ -1,0 +1,66 @@
+import Immutable from "immutable";
+import { parserFor } from "../../../app/oz/parser";
+import expressionsGrammar from "../../../app/oz/grammar/expressions.ne";
+import {
+  conditionalExpression,
+  literalExpression,
+  identifierExpression,
+} from "../../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import { literalNumber } from "../../../app/oz/machine/literals";
+import {
+  skipStatementSyntax,
+  sequenceStatementSyntax,
+} from "../../../app/oz/machine/statementSyntax";
+
+const parse = parserFor(expressionsGrammar);
+
+describe("Parsing conditional statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("parses simple if ... then ... else ... end statements", () => {
+    expect(parse("if X then skip 5 else skip skip 10 end")).toEqual(
+      conditionalExpression(
+        identifierExpression(lexicalIdentifier("X")),
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(10)),
+        },
+      ),
+    );
+  });
+
+  it("parses simple if ... then ... else ... end statements without statements in the clauses", () => {
+    expect(parse("if X then 5 else 10 end")).toEqual(
+      conditionalExpression(
+        identifierExpression(lexicalIdentifier("X")),
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      ),
+    );
+  });
+
+  it("parses simple if ... then ... end statements", () => {
+    expect(parse("if X then skip 5 end")).toEqual(
+      conditionalExpression(identifierExpression(lexicalIdentifier("X")), {
+        statement: skipStatementSyntax(),
+        expression: literalExpression(literalNumber(5)),
+      }),
+    );
+  });
+});

--- a/specs/parser/expressions/exception_context_spec.js
+++ b/specs/parser/expressions/exception_context_spec.js
@@ -1,0 +1,56 @@
+import Immutable from "immutable";
+import { parserFor } from "../../../app/oz/parser";
+import expressionsGrammar from "../../../app/oz/grammar/expressions.ne";
+import {
+  exceptionContextExpression,
+  literalExpression,
+} from "../../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import { literalNumber } from "../../../app/oz/machine/literals";
+import {
+  skipStatementSyntax,
+  sequenceStatementSyntax,
+} from "../../../app/oz/machine/statementSyntax";
+
+const parse = parserFor(expressionsGrammar);
+
+describe("Parsing exception context statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("parses when there are inner statements", () => {
+    expect(parse("try skip 5 catch Error then skip skip 10 end")).toEqual(
+      exceptionContextExpression(
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: sequenceStatementSyntax(
+            skipStatementSyntax(),
+            skipStatementSyntax(),
+          ),
+          expression: literalExpression(literalNumber(10)),
+        },
+        lexicalIdentifier("Error"),
+      ),
+    );
+  });
+
+  it("parses when there are no inner statements", () => {
+    expect(parse("try 5 catch Error then 10 end")).toEqual(
+      exceptionContextExpression(
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+        lexicalIdentifier("Error"),
+      ),
+    );
+  });
+});

--- a/specs/parser/expressions/local_spec.js
+++ b/specs/parser/expressions/local_spec.js
@@ -1,0 +1,28 @@
+import Immutable from "immutable";
+import { parserFor } from "../../../app/oz/parser";
+import expressionsGrammar from "../../../app/oz/grammar/expressions.ne";
+import {
+  localExpression,
+  literalExpression,
+} from "../../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import { literalNumber } from "../../../app/oz/machine/literals";
+import { skipStatementSyntax } from "../../../app/oz/machine/statementSyntax";
+
+const parse = parserFor(expressionsGrammar);
+
+describe("Parsing local statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("parses", () => {
+    expect(parse("local X Y in skip 5 end")).toEqual(
+      localExpression(
+        [lexicalIdentifier("X"), lexicalIdentifier("Y")],
+        literalExpression(literalNumber(5)),
+        skipStatementSyntax(),
+      ),
+    );
+  });
+});

--- a/specs/parser/expressions/pattern_matching_spec.js
+++ b/specs/parser/expressions/pattern_matching_spec.js
@@ -1,0 +1,281 @@
+import Immutable from "immutable";
+import { parserFor } from "../../../app/oz/parser";
+import expressionsGrammar from "../../../app/oz/grammar/expressions.ne";
+import {
+  patternMatchingExpression,
+  literalExpression,
+  identifierExpression,
+  operatorExpression,
+} from "../../../app/oz/machine/expressions";
+import { lexicalIdentifier } from "../../../app/oz/machine/lexical";
+import {
+  literalRecord,
+  literalAtom,
+  literalNumber,
+  literalString,
+  literalBoolean,
+  literalTuple,
+  literalList,
+  literalListItem,
+} from "../../../app/oz/machine/literals";
+import {
+  skipStatementSyntax,
+  bindingStatementSyntax,
+} from "../../../app/oz/machine/statementSyntax";
+
+const parse = parserFor(expressionsGrammar);
+
+describe("Parsing pattern matching statement expressions", () => {
+  beforeEach(() => {
+    jasmine.addCustomEqualityTester(Immutable.is);
+  });
+
+  it("handles multiple pattern cases with statements and expressions", () => {
+    expect(
+      parse(
+        "case X of person then A = B 5 [] animal then B = C 10 [] mineral then C = D 15 else skip 20 end",
+      ),
+    ).toEqual(
+      patternMatchingExpression(
+        identifierExpression(lexicalIdentifier("X")),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: bindingStatementSyntax(
+              identifierExpression(lexicalIdentifier("A")),
+              identifierExpression(lexicalIdentifier("B")),
+            ),
+            expression: literalExpression(literalNumber(5)),
+          },
+          {
+            pattern: literalRecord("animal"),
+            statement: bindingStatementSyntax(
+              identifierExpression(lexicalIdentifier("B")),
+              identifierExpression(lexicalIdentifier("C")),
+            ),
+            expression: literalExpression(literalNumber(10)),
+          },
+          {
+            pattern: literalRecord("mineral"),
+            statement: bindingStatementSyntax(
+              identifierExpression(lexicalIdentifier("C")),
+              identifierExpression(lexicalIdentifier("D")),
+            ),
+            expression: literalExpression(literalNumber(15)),
+          },
+        ],
+        {
+          statement: skipStatementSyntax(),
+          expression: literalExpression(literalNumber(20)),
+        },
+      ),
+    );
+  });
+
+  it("handles multiple pattern cases with expressions", () => {
+    expect(
+      parse(
+        "case X of person then 5 [] animal then 10 [] mineral then 15 else 20 end",
+      ),
+    ).toEqual(
+      patternMatchingExpression(
+        identifierExpression(lexicalIdentifier("X")),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: undefined,
+            expression: literalExpression(literalNumber(5)),
+          },
+          {
+            pattern: literalRecord("animal"),
+            statement: undefined,
+            expression: literalExpression(literalNumber(10)),
+          },
+          {
+            pattern: literalRecord("mineral"),
+            statement: undefined,
+            expression: literalExpression(literalNumber(15)),
+          },
+        ],
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(20)),
+        },
+      ),
+    );
+  });
+
+  it("handles no else clause", () => {
+    expect(parse("case X of person then 5 end")).toEqual(
+      patternMatchingExpression(identifierExpression(lexicalIdentifier("X")), [
+        {
+          pattern: literalRecord("person"),
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+      ]),
+    );
+  });
+
+  it("handles expressions", () => {
+    expect(parse("case A + B of person then 5 else 10 end")).toEqual(
+      patternMatchingExpression(
+        operatorExpression(
+          "+",
+          identifierExpression(lexicalIdentifier("A")),
+          identifierExpression(lexicalIdentifier("B")),
+        ),
+        [
+          {
+            pattern: literalRecord("person"),
+            statement: undefined,
+            expression: literalExpression(literalNumber(5)),
+          },
+        ],
+        {
+          statement: undefined,
+          expression: literalExpression(literalNumber(10)),
+        },
+      ),
+    );
+  });
+
+  describe("patterns", () => {
+    const simpleCaseWithPattern = pattern =>
+      patternMatchingExpression(identifierExpression(lexicalIdentifier("X")), [
+        {
+          pattern,
+          statement: undefined,
+          expression: literalExpression(literalNumber(5)),
+        },
+      ]);
+
+    it("handles identifiers", () => {
+      expect(parse("case X of Y then 5 end")).toEqual(
+        simpleCaseWithPattern(lexicalIdentifier("Y")),
+      );
+    });
+
+    it("handles numbers", () => {
+      expect(parse("case X of 12 then 5 end")).toEqual(
+        simpleCaseWithPattern(literalNumber(12)),
+      );
+    });
+
+    it("handles atoms", () => {
+      expect(parse("case X of person then 5 end")).toEqual(
+        simpleCaseWithPattern(literalAtom("person")),
+      );
+    });
+
+    it("handles strings", () => {
+      expect(parse('case X of "ABC" then 5 end')).toEqual(
+        simpleCaseWithPattern(literalString("ABC")),
+      );
+    });
+
+    it("handles booleans", () => {
+      expect(parse("case X of true then 5 end")).toEqual(
+        simpleCaseWithPattern(literalBoolean(true)),
+      );
+    });
+
+    it("handles generic records", () => {
+      expect(
+        parse(
+          "case X of person(name:N address:address(number:172 street:S)) then 5 end",
+        ),
+      ).toEqual(
+        simpleCaseWithPattern(
+          literalRecord("person", {
+            name: lexicalIdentifier("N"),
+            address: literalRecord("address", {
+              number: literalNumber(172),
+              street: lexicalIdentifier("S"),
+            }),
+          }),
+        ),
+      );
+    });
+
+    it("handles generic tuples", () => {
+      expect(parse("case X of vector(10 Y 20#Z) then 5 end")).toEqual(
+        simpleCaseWithPattern(
+          literalTuple("vector", [
+            literalNumber(10),
+            lexicalIdentifier("Y"),
+            literalTuple("#", [literalNumber(20), lexicalIdentifier("Z")]),
+          ]),
+        ),
+      );
+    });
+
+    it("handles generic lists", () => {
+      expect(parse("case X of [10 Y H|T] then 5 end")).toEqual(
+        simpleCaseWithPattern(
+          literalList([
+            literalNumber(10),
+            lexicalIdentifier("Y"),
+            literalListItem(lexicalIdentifier("H"), lexicalIdentifier("T")),
+          ]),
+        ),
+      );
+    });
+
+    it("handles any identifier in generic tuples", () => {
+      expect(parse("case X of vector(10 _ 20#_) then 5 end")).toEqual(
+        simpleCaseWithPattern(
+          literalTuple("vector", [
+            literalNumber(10),
+            lexicalIdentifier("_"),
+            literalTuple("#", [literalNumber(20), lexicalIdentifier("_")]),
+          ]),
+        ),
+      );
+    });
+
+    it("handles any identifier as identifier", () => {
+      expect(parse("case X of _ then 5 end")).toEqual(
+        simpleCaseWithPattern(lexicalIdentifier("_")),
+      );
+    });
+
+    it("handles any identifier in feture record", () => {
+      expect(parse("case X of person(age:30 name:_) then 5 end")).toEqual(
+        simpleCaseWithPattern(
+          literalRecord("person", {
+            age: literalNumber(30),
+            name: lexicalIdentifier("_"),
+          }),
+        ),
+      );
+    });
+
+    it("handles any identifier in features of nested record", () => {
+      expect(
+        parse("case X of person(name:_ address:address(number:_)) then 5 end"),
+      ).toEqual(
+        simpleCaseWithPattern(
+          literalRecord("person", {
+            name: lexicalIdentifier("_"),
+            address: literalRecord("address", {
+              number: lexicalIdentifier("_"),
+            }),
+          }),
+        ),
+      );
+    });
+
+    it("handles any identifier in lists", () => {
+      expect(parse("case X of [10 _ H|_] then 5 end")).toEqual(
+        simpleCaseWithPattern(
+          literalList([
+            literalNumber(10),
+            lexicalIdentifier("_"),
+            literalListItem(lexicalIdentifier("H"), lexicalIdentifier("_")),
+          ]),
+        ),
+      );
+    });
+  });
+});

--- a/specs/print/expressions/identifier_spec.js
+++ b/specs/print/expressions/identifier_spec.js
@@ -23,4 +23,12 @@ describe("Printing an identifier expression", () => {
     expect(result.abbreviated).toEqual("`@system`");
     expect(result.full).toEqual("`@system`");
   });
+
+  it("returns the appropriate string with the any identifier", () => {
+    const expression = identifierExpression(lexicalIdentifier("_"));
+    const result = print(expression, 2);
+
+    expect(result.abbreviated).toEqual("_");
+    expect(result.full).toEqual("_");
+  });
 });


### PR DESCRIPTION
## Summary of changes

* Implements compilable expressions for the 4 statements that can be used as expressions: local, conditional, exception context and pattern matching

## Related issues

* Closes kozily/admin#166