### PR TITLE
169 - Fixes parser error on literal zero

### DIFF
--- a/app/oz/grammar/grammar.ne
+++ b/app/oz/grammar/grammar.ne
@@ -767,6 +767,7 @@ lit_string_syntax -> "\"" ([^"\\] | lib_pseudo_char):* "\"" {%
 ##############################################################################
 lit_char ->
     lit_numeric_char {% litBuildNumber %}
+  | lit_zero_char {% litBuildNumber %}
   | lit_quoted_char {% litBuildNumber %}
   | lit_escaped_char {% litBuildNumber %}
 
@@ -778,6 +779,12 @@ lit_numeric_char -> [1-9] [0-9]:* {%
     } else {
       return value;
     }
+  }
+%}
+
+lit_zero_char -> "0" {%
+  function(d) {
+    return 0;
   }
 %}
 

--- a/specs/parser/literals/char_spec.js
+++ b/specs/parser/literals/char_spec.js
@@ -11,6 +11,7 @@ describe("Parsing char literals", () => {
   });
 
   it("handles numeric characters correctly", () => {
+    expect(parse("0")).toEqual(literalNumber(0));
     expect(parse("40")).toEqual(literalNumber(40));
     expect(parse("255")).toEqual(literalNumber(255));
   });


### PR DESCRIPTION
## Summary of changes

* Fixes parser error due to the literal 0 not being recognized by either character or integer.

## Related issues

* Closes kozily/admin#169